### PR TITLE
Add build flag for protobuff

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/rpcpool/yellowstone-vixen"
 
 [dependencies]
 bs58 = "0.5.1"
-thiserror = "1.0.59"
+thiserror = "1.0.64"
 yellowstone-grpc-proto = { workspace = true }
 yellowstone-vixen-proto = { workspace = true, optional = true }
 

--- a/crates/proto/build.rs
+++ b/crates/proto/build.rs
@@ -7,6 +7,7 @@ fn main() {
     {
         prost_build::Config::new()
             .enable_type_names()
+            .protoc_arg("--experimental_allow_proto3_optional")
             .file_descriptor_set_path(out_dir.join("vixen.parser.bin"))
             .compile_protos(&["proto/parser.proto"], &["proto"])
             .unwrap();

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -20,7 +20,7 @@ pin-project-lite = { version = "0.2.14", optional = true }
 prometheus = { version = "0.13.4", features = ["push"], optional = true }
 serde = { version = "1.0.198", features = ["derive"] }
 smallvec = "1.13.2"
-thiserror = "1.0.59"
+thiserror = "1.0.64"
 tokio = { version = "1.37.0", features = ["rt-multi-thread", "signal"] }
 topograph = { version = "0.4.0", features = [
     "tokio",


### PR DESCRIPTION
This pr's needs zeroize fixes to build.
This pr add the experimental flag to make it compatible with older versions of protobuf.