### PR TITLE
Use crates for grpc client and proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6247,7 +6247,8 @@ dependencies = [
 [[package]]
 name = "yellowstone-grpc-client"
 version = "2.0.0"
-source = "git+https://github.com/rpcpool/yellowstone-grpc?branch=master#348b67a666c2638c20482d2f3cf5e110279a4f6b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c73838262cb899d64e2c94ac6ca2fb5bc5d565aa4f04a68b969645a40a06c2c"
 dependencies = [
  "bytes",
  "futures",
@@ -6260,7 +6261,8 @@ dependencies = [
 [[package]]
 name = "yellowstone-grpc-proto"
 version = "2.0.0"
-source = "git+https://github.com/rpcpool/yellowstone-grpc?branch=master#348b67a666c2638c20482d2f3cf5e110279a4f6b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b740e0601335c649640732e4cb4061a4ef4bb27017e8e76e4caa3c03566dd0e"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,8 +3,8 @@ members = ["crates/*", "examples/*"]
 resolver = "2"
 
 [workspace.dependencies]
-yellowstone-grpc-client = { version = "2.0.0", git = "https://github.com/rpcpool/yellowstone-grpc", branch = "master" }
-yellowstone-grpc-proto = { version = "2.0.0", git = "https://github.com/rpcpool/yellowstone-grpc", branch = "master", default-features = false }
+yellowstone-grpc-client = { version = "2.0.0" }
+yellowstone-grpc-proto = { version = "2.0.0", default-features = false }
 yellowstone-vixen = { path = "crates/runtime", version = "0.0.0" }
 yellowstone-vixen-core = { path = "crates/core", version = "0.0.0" }
 yellowstone-vixen-mock = { path = "crates/mock", version = "0.0.0" }


### PR DESCRIPTION
1. use published crates for yellowstone-grpc-client and yellowstone-grpc-proto