### PR TITLE
Truncate Parser Identifiers

### DIFF
--- a/crates/core/src/proto.rs
+++ b/crates/core/src/proto.rs
@@ -46,50 +46,66 @@ pub struct Proto<T>(T);
 impl<T> Proto<T> {
     /// Wrap the provided parser in a new `Proto` instance
     #[inline]
-    pub fn new(value: T) -> Self { Self(value) }
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
 
     /// Return the parser contained within this `Proto` instance
     #[inline]
-    pub fn into_inner(self) -> T { self.0 }
+    pub fn into_inner(self) -> T {
+        self.0
+    }
 }
 
 impl<T> From<T> for Proto<T> {
     #[inline]
-    fn from(value: T) -> Self { Self(value) }
+    fn from(value: T) -> Self {
+        Self(value)
+    }
 }
 
 impl<T> std::ops::Deref for Proto<T> {
     type Target = T;
 
     #[inline]
-    fn deref(&self) -> &Self::Target { &self.0 }
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl<T> std::ops::DerefMut for Proto<T> {
     #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target { &mut self.0 }
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl<T: ParseProto + ProgramParser + Sync> ProgramParser for Proto<T>
-where T::Input: Sync
+where
+    T::Input: Sync,
 {
     #[inline]
-    fn program_id(&self) -> crate::Pubkey { self.0.program_id() }
+    fn program_id(&self) -> crate::Pubkey {
+        self.0.program_id()
+    }
 }
 
 impl<T: ParseProto + Sync> Parser for Proto<T>
-where T::Input: Sync
+where
+    T::Input: Sync,
 {
     type Input = T::Input;
     type Output = T::Message;
 
     #[inline]
     fn id(&self) -> std::borrow::Cow<str> {
-        format!("yellowstone_vixen_core::proto::Proto<{}>", self.0.id()).into()
+        self.0.id()
     }
 
     #[inline]
-    fn prefilter(&self) -> crate::Prefilter { self.0.prefilter() }
+    fn prefilter(&self) -> crate::Prefilter {
+        self.0.prefilter()
+    }
 
     #[inline]
     async fn parse(&self, value: &Self::Input) -> crate::ParseResult<Self::Output> {

--- a/crates/parser/src/orca/account_parser.rs
+++ b/crates/parser/src/orca/account_parser.rs
@@ -45,7 +45,9 @@ impl Parser for AccountParser {
     type Input = AccountUpdate;
     type Output = OrcaProgramState;
 
-    fn id(&self) -> Cow<str> { "yellowstone_vixen_parser::orca::AccountParser".into() }
+    fn id(&self) -> Cow<str> {
+        "orca::AccountParser".into()
+    }
 
     fn prefilter(&self) -> Prefilter {
         Prefilter::builder()

--- a/crates/parser/src/orca/instruction_parser.rs
+++ b/crates/parser/src/orca/instruction_parser.rs
@@ -18,7 +18,9 @@ impl Parser for InstructionParser {
     type Input = InstructionUpdate;
     type Output = OrcaProgramIx;
 
-    fn id(&self) -> Cow<str> { "yellowstone_vixen_parser::orca::InstructionParser".into() }
+    fn id(&self) -> Cow<str> {
+        "orca::InstructionParser".into()
+    }
 
     fn prefilter(&self) -> yellowstone_vixen_core::Prefilter {
         yellowstone_vixen_core::Prefilter::builder()
@@ -123,7 +125,9 @@ mod proto_parser {
     impl ParseProto for InstructionParser {
         type Message = OrcaProgramIxProto;
 
-        fn output_into_message(value: Self::Output) -> Self::Message { value.into_proto() }
+        fn output_into_message(value: Self::Output) -> Self::Message {
+            value.into_proto()
+        }
     }
 }
 

--- a/crates/parser/src/raydium/account_parser.rs
+++ b/crates/parser/src/raydium/account_parser.rs
@@ -64,7 +64,7 @@ impl Parser for AccountParser {
     type Output = RaydiumProgramState;
 
     fn id(&self) -> std::borrow::Cow<str> {
-        "yellowstone_vixen_parser::raydium::AccountParser".into()
+        "raydium::AccountParser".into()
     }
 
     fn prefilter(&self) -> Prefilter {

--- a/crates/parser/src/raydium/instruction_parser.rs
+++ b/crates/parser/src/raydium/instruction_parser.rs
@@ -20,7 +20,9 @@ impl Parser for InstructionParser {
     type Input = InstructionUpdate;
     type Output = RaydiumProgramIx;
 
-    fn id(&self) -> Cow<str> { "yellowstone_vixen_parser::raydium::InstructionParser".into() }
+    fn id(&self) -> Cow<str> {
+        "raydium::InstructionParser".into()
+    }
 
     fn prefilter(&self) -> Prefilter {
         Prefilter::builder()
@@ -119,7 +121,9 @@ mod proto_parser {
     impl ParseProto for InstructionParser {
         type Message = RaydiumProgramIxProto;
 
-        fn output_into_message(value: Self::Output) -> Self::Message { value.into_proto() }
+        fn output_into_message(value: Self::Output) -> Self::Message {
+            value.into_proto()
+        }
     }
 }
 

--- a/crates/parser/src/token_extension_program/account_parser.rs
+++ b/crates/parser/src/token_extension_program/account_parser.rs
@@ -116,7 +116,9 @@ impl Parser for AccountParser {
     type Input = AccountUpdate;
     type Output = TokenExtensionState;
 
-    fn id(&self) -> Cow<str> { "yellowstone_vixen_parser::token_extensions::AccountParser".into() }
+    fn id(&self) -> Cow<str> {
+        "token_extensions::AccountParser".into()
+    }
 
     fn prefilter(&self) -> Prefilter {
         Prefilter::builder()
@@ -133,7 +135,9 @@ impl Parser for AccountParser {
 
 impl ProgramParser for AccountParser {
     #[inline]
-    fn program_id(&self) -> yellowstone_vixen_core::Pubkey { spl_token_2022::ID.to_bytes().into() }
+    fn program_id(&self) -> yellowstone_vixen_core::Pubkey {
+        spl_token_2022::ID.to_bytes().into()
+    }
 }
 
 #[cfg(feature = "proto")]

--- a/crates/parser/src/token_extension_program/instruction_parser.rs
+++ b/crates/parser/src/token_extension_program/instruction_parser.rs
@@ -33,7 +33,7 @@ impl Parser for InstructionParser {
     type Output = TokenExtensionProgramIx;
 
     fn id(&self) -> std::borrow::Cow<str> {
-        "yellowstone_vixen_parser::token_extensions::InstructionParser".into()
+        "token_extensions::InstructionParser".into()
     }
 
     fn prefilter(&self) -> Prefilter {
@@ -53,7 +53,9 @@ impl Parser for InstructionParser {
 }
 
 impl ProgramParser for InstructionParser {
-    fn program_id(&self) -> yellowstone_vixen_core::Pubkey { spl_token_2022::ID.to_bytes().into() }
+    fn program_id(&self) -> yellowstone_vixen_core::Pubkey {
+        spl_token_2022::ID.to_bytes().into()
+    }
 }
 
 impl InstructionParser {
@@ -265,7 +267,9 @@ mod proto_parser {
     impl ParseProto for InstructionParser {
         type Message = TokenExtensionProgramIxProto;
 
-        fn output_into_message(value: Self::Output) -> Self::Message { value.into_proto() }
+        fn output_into_message(value: Self::Output) -> Self::Message {
+            value.into_proto()
+        }
     }
 }
 

--- a/crates/parser/src/token_program/account_parser.rs
+++ b/crates/parser/src/token_program/account_parser.rs
@@ -37,7 +37,9 @@ impl Parser for AccountParser {
     type Input = AccountUpdate;
     type Output = TokenProgramState;
 
-    fn id(&self) -> Cow<str> { "yellowstone_vixen_parser::token_program::AccountParser".into() }
+    fn id(&self) -> Cow<str> {
+        "token_program::AccountParser".into()
+    }
 
     fn prefilter(&self) -> Prefilter {
         Prefilter::builder()
@@ -55,7 +57,9 @@ impl Parser for AccountParser {
 
 impl ProgramParser for AccountParser {
     #[inline]
-    fn program_id(&self) -> yellowstone_vixen_core::Pubkey { spl_token::ID.to_bytes().into() }
+    fn program_id(&self) -> yellowstone_vixen_core::Pubkey {
+        spl_token::ID.to_bytes().into()
+    }
 }
 
 #[cfg(feature = "proto")]

--- a/crates/parser/src/token_program/instruction_parser.rs
+++ b/crates/parser/src/token_program/instruction_parser.rs
@@ -18,7 +18,7 @@ impl Parser for InstructionParser {
     type Output = TokenProgramIx;
 
     fn id(&self) -> std::borrow::Cow<str> {
-        "yellowstone_vixen_parser::token_program::InstructionParser".into()
+        "token_program::InstructionParser".into()
     }
 
     fn prefilter(&self) -> Prefilter {
@@ -39,7 +39,9 @@ impl Parser for InstructionParser {
 
 impl ProgramParser for InstructionParser {
     #[inline]
-    fn program_id(&self) -> yellowstone_vixen_core::Pubkey { spl_token::ID.to_bytes().into() }
+    fn program_id(&self) -> yellowstone_vixen_core::Pubkey {
+        spl_token::ID.to_bytes().into()
+    }
 }
 
 impl InstructionParser {
@@ -365,7 +367,9 @@ mod proto_parser {
     impl ParseProto for InstructionParser {
         type Message = TokenProgramIxProto;
 
-        fn output_into_message(value: Self::Output) -> Self::Message { value.into_proto() }
+        fn output_into_message(value: Self::Output) -> Self::Message {
+            value.into_proto()
+        }
     }
 }
 

--- a/crates/runtime/src/instruction.rs
+++ b/crates/runtime/src/instruction.rs
@@ -76,7 +76,7 @@ impl<M: Instrumenter> InstructionPipeline<M> {
 
 impl<M: Instrumenter> ParserId for InstructionPipeline<M> {
     fn id(&self) -> std::borrow::Cow<str> {
-        "yellowstone_vixen::instruction::InstructionPipeline".into()
+        "InstructionPipeline".into()
     }
 }
 


### PR DESCRIPTION
## Changes
Dragon's mouth now requires filter identifiers to be below 32 characters. The current identifiers were longer than that reduced their length to meet the requirement.

## Notes
- There is no validation in vixen for id length because I couldn't see a way to enforce in type system in order to throw error during build. GRPC already returns a runtime error.