### PR TITLE
Subscribe to block meta updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- New features under development.
+- Official Pump Fun parser (https://github.com/rpcpool/yellowstone-vixen/pull/66)
+- Subscribe to block_meta (https://github.com/rpcpool/yellowstone-vixen/pull/67)
 
 ### Changed
 

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -32,6 +32,7 @@ tokio = "1.39.2"
 
 [features]
 default = []
+block-meta = []
 proto = [
   "dep:yellowstone-vixen-proto",
   "yellowstone-vixen-core/proto",

--- a/crates/parser/src/block_meta.rs
+++ b/crates/parser/src/block_meta.rs
@@ -1,0 +1,87 @@
+use std::borrow::Cow;
+
+use yellowstone_vixen_core::{
+    BlockMetaUpdate, ParseResult, Parser, Prefilter, ProgramParser, Pubkey,
+};
+
+#[derive(Debug, Clone)]
+pub struct Reward {
+    pub pubkey: String,
+    pub lamports: i64,
+    pub post_balance: u64,
+    pub reward_type: i32,
+    pub commission: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct Rewards {
+    pub rewards: Vec<Reward>,
+    pub num_partitions: Option<u64>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlockUpdate {
+    pub slot: u64,
+    pub blockhash: String,
+    pub rewards: Option<Rewards>,
+    pub block_time: Option<i64>,
+    pub block_height: Option<u64>,
+    pub parent_slot: u64,
+    pub parent_blockhash: String,
+    pub executed_transaction_count: u64,
+    pub entries_count: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BlockMetaParser;
+
+impl Parser for BlockMetaParser {
+    type Input = BlockMetaUpdate;
+    type Output = BlockUpdate;
+
+    fn id(&self) -> Cow<str> { "yellowstone::BlockMetaParser".into() }
+
+    fn prefilter(&self) -> Prefilter { Prefilter::builder().build().unwrap() }
+
+    async fn parse(&self, block_meta: &BlockMetaUpdate) -> ParseResult<Self::Output> {
+        let rewards = block_meta.rewards.as_ref().map(|reward| Rewards {
+            rewards: reward
+                .rewards
+                .iter()
+                .map(|reward| Reward {
+                    pubkey: reward.pubkey.clone(),
+                    lamports: reward.lamports,
+                    post_balance: reward.post_balance,
+                    reward_type: reward.reward_type,
+                    commission: reward.commission.clone(),
+                })
+                .collect(),
+            num_partitions: reward.num_partitions.map(|num| num.num_partitions),
+        });
+
+        Ok(BlockUpdate {
+            slot: block_meta.slot,
+            blockhash: block_meta.blockhash.clone(),
+            rewards,
+            block_time: block_meta.block_time.map(|block_time| block_time.timestamp),
+            block_height: block_meta
+                .block_height
+                .map(|block_height| block_height.block_height),
+            parent_slot: block_meta.parent_slot,
+            parent_blockhash: block_meta.parent_blockhash.clone(),
+            executed_transaction_count: block_meta.executed_transaction_count,
+            entries_count: block_meta.entries_count,
+        })
+    }
+}
+
+impl ProgramParser for BlockMetaParser {
+    /// "B111111111111111111111111111111111111111112"
+    #[inline]
+    fn program_id(&self) -> Pubkey {
+        Pubkey::new([
+            2, 143, 206, 223, 9, 17, 53, 163, 33, 32, 251, 255, 120, 243, 177, 49, 160, 203, 100,
+            118, 223, 255, 122, 65, 91, 88, 104, 0, 0, 0, 0, 1,
+        ])
+    }
+}

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -15,6 +15,9 @@ pub use error::*;
 
 mod helpers;
 
+#[cfg(feature = "block-meta")]
+pub mod block_meta;
+
 #[cfg(feature = "orca")]
 pub mod orca;
 #[cfg(feature = "raydium")]

--- a/crates/runtime/src/buffer.rs
+++ b/crates/runtime/src/buffer.rs
@@ -90,6 +90,13 @@ impl<M: Instrumenter, H: Send> topograph::AsyncHandler<Job, H> for Handler<M> {
                     .run(span, &t, counters)
                     .await;
             },
+            UpdateOneof::BlockMeta(b) => {
+                pipelines
+                    .block_meta
+                    .get_handlers(&filters)
+                    .run(span, &b, counters)
+                    .await;
+            },
             UpdateOneof::Ping(SubscribeUpdatePing {}) => (),
             var => warn!(?var, "Unknown update variant"),
         }

--- a/crates/runtime/src/handler.rs
+++ b/crates/runtime/src/handler.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, collections::HashMap, pin::Pin};
 use futures_util::{Future, FutureExt, StreamExt};
 use smallvec::SmallVec;
 use tracing::{warn, Instrument, Span};
-use vixen_core::{AccountUpdate, GetPrefilter, ParserId, TransactionUpdate};
+use vixen_core::{AccountUpdate, BlockMetaUpdate, GetPrefilter, ParserId, TransactionUpdate};
 use yellowstone_vixen_core::{Filters, ParseError, Parser, Prefilter};
 
 use crate::metrics::{Counters, Instrumenter, JobResult, Update};
@@ -224,6 +224,7 @@ impl<T> DynPipeline<T> for BoxPipeline<'_, T> {
 pub(crate) struct PipelineSets {
     pub account: PipelineSet<BoxPipeline<'static, AccountUpdate>>,
     pub transaction: PipelineSet<BoxPipeline<'static, TransactionUpdate>>,
+    pub block_meta: PipelineSet<BoxPipeline<'static, BlockMetaUpdate>>,
 }
 
 impl PipelineSets {
@@ -233,6 +234,7 @@ impl PipelineSets {
             self.account
                 .filters()
                 .chain(self.transaction.filters())
+                .chain(self.block_meta.filters())
                 .collect(),
         )
     }

--- a/crates/runtime/src/metrics.rs
+++ b/crates/runtime/src/metrics.rs
@@ -332,6 +332,10 @@ impl Update for vixen_core::TransactionUpdate {
     const TYPE: UpdateType = UpdateType::Transaction;
 }
 
+impl Update for vixen_core::BlockMetaUpdate {
+    const TYPE: UpdateType = UpdateType::BlockMeta;
+}
+
 /// Tuple of `(singular, plural)`
 #[derive(Clone, Copy)]
 struct Noun(&'static str, &'static str);
@@ -349,6 +353,7 @@ macro_rules! noun_formatters {
 pub(crate) enum UpdateType {
     Account,
     Transaction,
+    BlockMeta,
 }
 
 impl UpdateType {
@@ -358,6 +363,9 @@ impl UpdateType {
             Some(UpdateOneof::Transaction(vixen_core::TransactionUpdate { .. })) => {
                 Some(Self::Transaction)
             },
+            Some(UpdateOneof::BlockMeta(vixen_core::BlockMetaUpdate { .. })) => {
+                Some(Self::BlockMeta)
+            },
             _ => None,
         }
     }
@@ -366,6 +374,7 @@ impl UpdateType {
         match self {
             UpdateType::Account => Noun("account", "accounts"),
             UpdateType::Transaction => Noun("transaction", "transactions"),
+            UpdateType::BlockMeta => Noun("block_meta", "block_metas"),
         }
     }
 }
@@ -373,6 +382,7 @@ impl UpdateType {
 struct UpdateCounters<B: Instrumenter> {
     account: B::Counter,
     transaction: B::Counter,
+    block_meta: B::Counter,
 }
 
 impl<B: Instrumenter> UpdateCounters<B> {
@@ -381,6 +391,7 @@ impl<B: Instrumenter> UpdateCounters<B> {
         Self {
             account: f(UpdateType::Account),
             transaction: f(UpdateType::Transaction),
+            block_meta: f(UpdateType::BlockMeta),
         }
     }
 
@@ -388,6 +399,7 @@ impl<B: Instrumenter> UpdateCounters<B> {
         match ty {
             UpdateType::Account => &self.account,
             UpdateType::Transaction => &self.transaction,
+            UpdateType::BlockMeta => &self.block_meta,
         }
     }
 }

--- a/examples/prometheus/Cargo.toml
+++ b/examples/prometheus/Cargo.toml
@@ -17,4 +17,5 @@ yellowstone-vixen-parser = { workspace = true, features = [
   "token-program",
   "orca",
   "raydium",
+  "block-meta",
 ] }


### PR DESCRIPTION
## Changes
- Add a official parser for block meta to parser crate
- Accept block_meta parsers

```rust
use yellowstone_vixen_parser::block_meta::BlockMetaParser;

    vixen::Runtime::builder()
        .block_meta(Pipeline::new(BlockMetaParser, [Logger]))
        .build(config)
        .run();
```