### PR TITLE
docs: update contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing to Yellowstone Vixen! This guide wil
 
 ## Getting Started
 
-To contribute to this project, you'll need to have Rust installed on your machine. The project uses the nightly toolchain for Rust, specifically `nightly-2024-02-01`. We also use a workspace structure with multiple crates.
+To contribute to this project, you'll need to have Rust installed on your machine. This project builds successfully with the latest **stable** Rust, and also with the latest **nightly**. We also use a workspace structure with multiple crates.
 
 ## Setting Up Your Environment
 
@@ -26,12 +26,7 @@ To contribute to this project, you'll need to have Rust installed on your machin
 
 2. **Install Rust and Set the Toolchain**
 
-   If you haven't installed Rust yet, you can do so by following the instructions on the [Rust website](https://www.rust-lang.org/). Once Rust is installed, set the toolchain to `nightly-2024-02-01`.
-
-   ```sh
-   rustup toolchain install nightly-2024-02-01
-   rustup override set nightly-2024-02-01
-   ```
+   If you haven't installed Rust yet, you can do so by following the instructions on the [Rust website](https://www.rust-lang.org/).
 
 3. **Build the Project**
 


### PR DESCRIPTION
### Summary
The contribution guide currently instructs contributors to install and use `nightly-2024-02-01`.  
That pinned toolchain no longer builds the project successfully.

- The project builds correctly on `rustc 1.89.0 (stable)` and `rustc 1.91.0-nightly` as of August 2025.

### Changes
- Updated instructions to recommend using the latest **stable** Rust or the latest **nightly**.
- Removed reference to the outdated `nightly-2024-02-01`.


