### PR TITLE
Use `unpack_from_slice` In Token Program Parser

### DIFF
--- a/crates/parser/src/token_program/account_parser.rs
+++ b/crates/parser/src/token_program/account_parser.rs
@@ -19,14 +19,16 @@ pub enum TokenProgramState {
 impl TokenProgramState {
     pub fn try_unpack(data_bytes: &[u8]) -> ParseResult<Self> {
         let acc = match data_bytes.len() {
-            Mint::LEN => Mint::unpack_from_slice(data_bytes).map(Self::Mint).map_err(Into::into),
+            Mint::LEN => Mint::unpack_from_slice(data_bytes)
+                .map(Self::Mint)
+                .map_err(Into::into),
             Account::LEN => Account::unpack_from_slice(data_bytes)
                 .map(Self::TokenAccount)
                 .map_err(Into::into),
             Multisig::LEN => Multisig::unpack_from_slice(data_bytes)
                 .map(Self::Multisig)
                 .map_err(Into::into),
-            _ => return Err(ParseError::Filtered)
+            _ => return Err(ParseError::Filtered),
         };
 
         #[cfg(feature = "tracing")]


### PR DESCRIPTION
It’s better for the TokenProgram parser to use `unpack_from_slice` instead of `unpack`, otherwise it may fail on uninitialized accounts. The handlers should be responsible for dealing with that logic.

I also replaced the `"Invalid Account data length"` error with `Err(ParseError::Filtered)` because the previous message was generating a lot of noise due to the large number of accounts with incorrect lengths.

<img width="950" height="358" alt="image" src="https://github.com/user-attachments/assets/6254857c-07ef-4f5b-a7be-33d7b14679aa" />
