### PR TITLE
remove entrypoint from spl-token-2022

### DIFF
--- a/crates/spl-token-extensions-parser/Cargo.toml
+++ b/crates/spl-token-extensions-parser/Cargo.toml
@@ -12,7 +12,7 @@ readme = "./../../README.md"
 
 [dependencies]
 spl-pod = { workspace = true }
-spl-token-2022 = { workspace = true }
+spl-token-2022 = { workspace = true, features = ["no-entrypoint"] }
 spl-type-length-value = { workspace = true }
 spl-token-group-interface = { workspace = true }
 spl-token-metadata-interface = { workspace = true }


### PR DESCRIPTION
Fixes linker error: multiple `entrypoint` symbols