### PR TITLE
fix index 0 panic in spl extension

### DIFF
--- a/crates/spl-token-extensions-parser/src/extensions/extension.rs
+++ b/crates/spl-token-extensions-parser/src/extensions/extension.rs
@@ -5,7 +5,7 @@ pub fn decode_extension_ix_type<T: TryFrom<u8>>(ix_data: &[u8]) -> Result<T>
 where T::Error: std::error::Error + Send + Sync + 'static {
 
     let first_byte: u8 = *ix_data.get(0)
-        .ok_or_else(|| yellowstone_vixen_parser::Error::new("Instruction data for token extension is empty"))?;
+        .ok_or(yellowstone_vixen_parser::Error::new("Instruction data for token extension is empty"))?;
 
     T::try_from(first_byte)
         .parse_err("Error decoding instruction data for token extension")


### PR DESCRIPTION


> panicked at /home/user/.cargo/git/checkouts/yellowstone-vixen-aa87956842e7c98e/943ca76/crates/spl-token-extensions-parser/src/extensions/extension.rs:6:17:
index out of bounds: the len is 0 but the index is 0
2025-12-13T13:52:27.277503Z ERROR ThreadId(09) vixen.process.transaction: yolotrader_misc::panic_hook: 14: panic occurred in file at line file="/home/user/.cargo/git/checkouts/yellowstone-vixen-aa87956842e7c98e/943ca76/crates/spl-token-extensions-parser/src/extensions/extension.rs" line=6

