### PR TITLE
feat: Backfill data report q1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ yellowstone-fumarole-client = "0.4.0+solana.3"
 yellowstone-grpc-client = { version = "12" }
 yellowstone-grpc-proto = { version = "12", default-features = false }
 rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "zstd"] }
-reqwest = { version = "0.12", features = ["json", "blocking"] }
+reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }
 
 yellowstone-vixen = { path = "crates/runtime", version = "0.6.1" }
 yellowstone-vixen-proc-macro = { path = "crates/proc-macro", version = "0.6.1" }

--- a/crates/jetstreamer-source/src/lib.rs
+++ b/crates/jetstreamer-source/src/lib.rs
@@ -6,7 +6,7 @@ use std::sync::{
 use async_trait::async_trait;
 use futures_util::FutureExt;
 use jetstreamer_firehose::firehose::{firehose, BlockData, OnErrorFn, TransactionData};
-use tokio::sync::{mpsc::Sender, oneshot};
+use tokio::sync::{mpsc, mpsc::Sender, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info};
 use yellowstone_grpc_proto::{
@@ -20,6 +20,12 @@ use yellowstone_vixen::{
 use yellowstone_vixen_core::Filters;
 
 type SharedError = Box<dyn std::error::Error + Send + Sync + 'static>;
+
+/// Dedicated side-channel event surfaced for skipped slots during backfill.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PossibleLeaderSkippedEvent {
+    pub slot: u64,
+}
 
 /// Env vars that `jetstreamer-firehose` reads at startup.
 ///
@@ -132,6 +138,7 @@ pub unsafe fn init_process_env(config: &JetstreamSourceConfig) {
 
 struct VixenStreamHandler {
     tx: Sender<Result<SubscribeUpdate, yellowstone_grpc_proto::tonic::Status>>,
+    skipped_slots_tx: Option<mpsc::Sender<PossibleLeaderSkippedEvent>>,
     // Cache matching filters to avoid iteration per item
     block_matches: Vec<String>,
     transaction_matches: Vec<String>,
@@ -142,6 +149,7 @@ struct VixenStreamHandler {
 impl VixenStreamHandler {
     fn new(
         tx: Sender<Result<SubscribeUpdate, yellowstone_grpc_proto::tonic::Status>>,
+        skipped_slots_tx: Option<mpsc::Sender<PossibleLeaderSkippedEvent>>,
         filters: Filters,
     ) -> Self {
         let (block_matches, transaction_matches) = Self::precalculate_filters(&filters);
@@ -154,6 +162,7 @@ impl VixenStreamHandler {
 
         Self {
             tx,
+            skipped_slots_tx,
             block_matches,
             transaction_matches,
             blocks_processed: AtomicU64::new(0),
@@ -274,7 +283,22 @@ impl VixenStreamHandler {
                 })?;
             },
             BlockData::PossibleLeaderSkipped { slot } => {
-                debug!(slot, "Skipping possibly leader-skipped slot");
+                debug!(
+                    slot,
+                    "Surfacing possibly leader-skipped slot on side channel"
+                );
+
+                if let Some(skipped_slots_tx) = &self.skipped_slots_tx {
+                    skipped_slots_tx
+                        .send(PossibleLeaderSkippedEvent { slot })
+                        .await
+                        .map_err(|e| {
+                            let error_msg =
+                                format!("Failed to send possible leader-skipped slot: {}", e);
+                            error!("{}", error_msg);
+                            Box::new(Error::ChannelSend(error_msg)) as SharedError
+                        })?;
+                }
             },
         }
 
@@ -370,6 +394,11 @@ pub struct JetstreamSourceConfig {
     /// Network capacity in MB
     #[arg(long, env, default_value = "1000")]
     pub network_capacity_mb: usize,
+
+    /// Optional side channel for `PossibleLeaderSkipped` events.
+    #[serde(skip)]
+    #[arg(skip)]
+    pub possible_leader_skipped_tx: Option<mpsc::Sender<PossibleLeaderSkippedEvent>>,
 }
 
 /// Configuration for slot ranges or epochs
@@ -390,27 +419,33 @@ pub struct SlotRangeConfig {
 }
 
 impl SlotRangeConfig {
-    /// Convert configuration to slot range
-    /// Returns (start_slot, end_slot)
+    /// Convert configuration to a half-open slot range.
+    ///
+    /// Returns `(start_slot, end_slot_exclusive)` — the range processed is
+    /// `[start_slot, end_slot_exclusive)`, matching Rust's `start..end`
+    /// semantics used by `firehose()`.
+    ///
+    /// - **Epoch mode**: covers all slots in the epoch.
+    /// - **Explicit mode**: `slot_start` is inclusive, `slot_end` is
+    ///   **exclusive** (the first slot *not* processed).
     pub fn to_slot_range(&self) -> Result<(u64, u64), Error> {
         match (self.slot_start, self.slot_end, self.epoch) {
             (Some(start), Some(end), None) => {
-                if start > end {
+                if start >= end {
                     return Err(Error::InvalidConfig(
-                        "slot_start must be <= slot_end".into(),
+                        "slot_start must be < slot_end (slot_end is exclusive)".into(),
                     ));
                 }
                 Ok((start, end))
             },
             (None, None, Some(epoch)) => {
-                // Mainnet/testnet use 432,000 slots per epoch
                 const SLOTS_PER_EPOCH: u64 = 432_000;
                 let start = epoch * SLOTS_PER_EPOCH;
-                let end = (epoch + 1) * SLOTS_PER_EPOCH - 1;
+                let end = (epoch + 1) * SLOTS_PER_EPOCH;
                 info!(
                     epoch,
                     start_slot = start,
-                    end_slot = end,
+                    end_slot_exclusive = end,
                     "Resolved epoch to slot range"
                 );
                 Ok((start, end))
@@ -496,7 +531,11 @@ impl JetstreamSource {
             "Starting Jetstream historical replay"
         );
 
-        let handler = Arc::new(VixenStreamHandler::new(tx.clone(), filters.clone()));
+        let handler = Arc::new(VixenStreamHandler::new(
+            tx.clone(),
+            config.possible_leader_skipped_tx.clone(),
+            filters.clone(),
+        ));
 
         let handler_on_block = handler.clone();
         let on_block = Some(move |_thread_id: usize, block: BlockData| {
@@ -610,9 +649,9 @@ mod tests {
             slot_end: None,
             epoch: Some(800),
         };
-        let (start, end) = config.to_slot_range().unwrap();
+        let (start, end_exclusive) = config.to_slot_range().unwrap();
         assert_eq!(start, 345_600_000);
-        assert_eq!(end, 346_031_999);
+        assert_eq!(end_exclusive, 346_032_000); // end-exclusive: first slot of next epoch
     }
 
     #[test]
@@ -623,6 +662,19 @@ mod tests {
             epoch: None,
         };
         assert!(config.to_slot_range().is_err());
+    }
+
+    #[test]
+    fn test_slot_range_empty_range_rejected() {
+        let config = SlotRangeConfig {
+            slot_start: Some(100),
+            slot_end: Some(100),
+            epoch: None,
+        };
+        assert!(
+            config.to_slot_range().is_err(),
+            "start == end is an empty range"
+        );
     }
 
     #[test]
@@ -648,6 +700,7 @@ mod tests {
             network: "mainnet".to_string(),
             compact_index_base_url: "https://files.old-faithful.net".to_string(),
             network_capacity_mb: 1000,
+            possible_leader_skipped_tx: None,
         };
 
         let filters = Filters::new(std::collections::HashMap::new());
@@ -658,6 +711,29 @@ mod tests {
         assert_eq!(source.config.network, "mainnet");
     }
 
+    #[tokio::test]
+    async fn possible_leader_skipped_events_use_side_channel() {
+        let (updates_tx, mut updates_rx) = mpsc::channel(4);
+        let (skipped_tx, mut skipped_rx) = mpsc::channel(4);
+        let handler = VixenStreamHandler::new(
+            updates_tx,
+            Some(skipped_tx),
+            Filters::new(std::collections::HashMap::new()),
+        );
+
+        handler
+            .process_block(BlockData::PossibleLeaderSkipped { slot: 123 })
+            .await
+            .expect("side-channel send should succeed");
+
+        let skipped = skipped_rx.recv().await.expect("skipped event");
+        assert_eq!(skipped, PossibleLeaderSkippedEvent { slot: 123 });
+        assert!(
+            updates_rx.try_recv().is_err(),
+            "no fake block update should be emitted"
+        );
+    }
+
     #[test]
     fn test_multiple_epochs() {
         for epoch in [800, 801, 802] {
@@ -666,9 +742,9 @@ mod tests {
                 slot_end: None,
                 epoch: Some(epoch),
             };
-            let (start, end) = config.to_slot_range().unwrap();
+            let (start, end_exclusive) = config.to_slot_range().unwrap();
             assert_eq!(start, epoch * 432_000);
-            assert_eq!(end, (epoch + 1) * 432_000 - 1);
+            assert_eq!(end_exclusive, (epoch + 1) * 432_000); // end-exclusive
         }
     }
 }

--- a/crates/kafka-sink/src/handler.rs
+++ b/crates/kafka-sink/src/handler.rs
@@ -109,7 +109,7 @@ impl vixen::Handler<TransactionUpdate, TransactionUpdate> for BufferingHandler {
             for ix in ix_update.visit_all() {
                 let (result, had_error) = self
                     .parsers
-                    .parse_instruction(slot, &ix.shared.signature, &ix.path, ix)
+                    .parse_instruction(slot, tx_index, &ix.shared.signature, &ix.path, ix)
                     .await;
 
                 if let Some(record) = result {

--- a/crates/kafka-sink/src/lib.rs
+++ b/crates/kafka-sink/src/lib.rs
@@ -23,8 +23,8 @@ pub use kafka_sink::TransactionSlotSink;
 pub use kafka_sink::{AccountMsg, AccountPassthroughSink, AccountSlotSink};
 pub use parsers::{AccountSubscription, TransactionSubscription};
 pub use producer::{create_producer, initialize_transactional_producer};
-// Re-export rdkafka types for convenience
-pub use rdkafka::producer::FutureProducer;
+// Re-export rdkafka producer types for convenience
+pub use rdkafka::producer::{FutureProducer, FutureRecord};
 pub use schema_registry::{
     ensure_schemas_registered, wrap_payload_with_confluent_wire_format, RegisteredSchema,
     SchemaDefinition,

--- a/crates/kafka-sink/src/sink.rs
+++ b/crates/kafka-sink/src/sink.rs
@@ -374,6 +374,7 @@ impl KafkaSink {
     pub async fn parse_instruction(
         &self,
         slot: u64,
+        tx_index: u64,
         signature: &[u8],
         path: &Path,
         ix: &InstructionUpdate,
@@ -390,6 +391,7 @@ impl KafkaSink {
                 ParseOutcome::Parsed(parsed) => {
                     let record = self.prepare_decoded_instruction_record(
                         slot,
+                        tx_index,
                         signature,
                         path,
                         parsed,
@@ -406,7 +408,7 @@ impl KafkaSink {
 
                     if let Some(fallback) = parser.fallback_topic() {
                         let record = self.prepare_fallback_instruction_record(
-                            slot, signature, path, ix, fallback,
+                            slot, tx_index, signature, path, ix, fallback,
                         );
 
                         return (Some(record), true);
@@ -420,6 +422,7 @@ impl KafkaSink {
     /// Build the base headers and key shared by all instruction record types.
     fn instruction_base_record(
         slot: u64,
+        tx_index: u64,
         signature: &[u8],
         path: &Path,
     ) -> (String, Vec<RecordHeader>) {
@@ -437,6 +440,10 @@ impl KafkaSink {
             RecordHeader {
                 key: "signature",
                 value: sig_str,
+            },
+            RecordHeader {
+                key: "tx_index",
+                value: tx_index.to_string(),
             },
             RecordHeader {
                 key: "ix_index",
@@ -469,12 +476,13 @@ impl KafkaSink {
     pub fn prepare_decoded_instruction_record(
         &self,
         slot: u64,
+        tx_index: u64,
         signature: &[u8],
         path: &Path,
         parsed: ParsedOutput,
         topic: &str,
     ) -> PreparedRecord {
-        let (key, headers) = Self::instruction_base_record(slot, signature, path);
+        let (key, headers) = Self::instruction_base_record(slot, tx_index, signature, path);
 
         let payload = self.encode_payload_for_topic(topic, parsed.data);
 
@@ -493,12 +501,13 @@ impl KafkaSink {
     pub fn prepare_fallback_instruction_record(
         &self,
         slot: u64,
+        tx_index: u64,
         signature: &[u8],
         path: &Path,
         ix: &InstructionUpdate,
         fallback_topic: &str,
     ) -> PreparedRecord {
-        let (key, mut headers) = Self::instruction_base_record(slot, signature, path);
+        let (key, mut headers) = Self::instruction_base_record(slot, tx_index, signature, path);
 
         let program_id = bs58::encode(ix.program).into_string();
 
@@ -867,7 +876,7 @@ mod tests {
         let ix = instruction_with_program([9; 32].into());
 
         let (record, had_error) =
-            futures::executor::block_on(sink.parse_instruction(100, b"sig", &ix.path, &ix));
+            futures::executor::block_on(sink.parse_instruction(100, 7, b"sig", &ix.path, &ix));
 
         assert!(
             record.is_none(),
@@ -897,7 +906,7 @@ mod tests {
         let ix = instruction_with_program([1; 32].into());
 
         let (record, had_error) =
-            futures::executor::block_on(sink.parse_instruction(100, b"sig", &ix.path, &ix));
+            futures::executor::block_on(sink.parse_instruction(100, 7, b"sig", &ix.path, &ix));
 
         assert!(record.is_none(), "filtered decode should not emit fallback");
         assert!(!had_error);
@@ -923,7 +932,7 @@ mod tests {
         let ix = instruction_with_program([1; 32].into());
 
         let (record, had_error) =
-            futures::executor::block_on(sink.parse_instruction(100, b"sig", &ix.path, &ix));
+            futures::executor::block_on(sink.parse_instruction(100, 7, b"sig", &ix.path, &ix));
 
         let record = record.expect("expected fallback record");
 
@@ -947,6 +956,14 @@ mod tests {
             event.data,
             yellowstone_vixen_core::bs58::encode([1_u8, 2, 3]).into_string()
         );
+        assert_eq!(
+            record
+                .headers
+                .iter()
+                .find(|header| header.key == "tx_index")
+                .map(|header| header.value.as_str()),
+            Some("7")
+        );
     }
 
     #[test]
@@ -969,13 +986,21 @@ mod tests {
         let ix = instruction_with_program([1; 32].into());
 
         let (record, had_error) =
-            futures::executor::block_on(sink.parse_instruction(100, b"sig", &ix.path, &ix));
+            futures::executor::block_on(sink.parse_instruction(100, 7, b"sig", &ix.path, &ix));
 
         let record = record.expect("expected decoded record");
 
         assert_eq!(record.topic, "test.instructions");
         assert!(!had_error);
         assert!(record.is_decoded);
+        assert_eq!(
+            record
+                .headers
+                .iter()
+                .find(|header| header.key == "tx_index")
+                .map(|header| header.value.as_str()),
+            Some("7")
+        );
     }
 
     #[cfg(feature = "experimental-account-parser")]

--- a/crates/runtime/src/buffer.rs
+++ b/crates/runtime/src/buffer.rs
@@ -210,7 +210,7 @@ impl Buffer {
                         Stop(StopCode),
                     }
 
-                    loop {
+                    let (result, drain_executor) = loop {
                         let event = tokio::select! {
                             u = stream.recv() => Event::Update(u),
                             c = &mut stop_rx => Event::Stop(c),
@@ -225,18 +225,26 @@ impl Buffer {
                                         message = %e.message(),
                                         "Yellowstone grpc stream error"
                                     );
-                                    return Err(crate::Error::YellowstoneStatus(e));
+                                    break (Err(crate::Error::YellowstoneStatus(e)), false);
                                 },
                             },
                             Event::Update(None) => {
-                                tracing::warn!("Server stopped sending updates");
-                                break Ok(StopCode::default());
+                                tracing::info!("Update stream closed");
+                                break (Ok(StopCode::default()), true);
                             },
-                            Event::Stop(c) => break Ok(c),
+                            Event::Stop(c) => break (Ok(c), false),
                         };
 
                         Self::dispatch(&exec, update);
+                    };
+
+                    if drain_executor {
+                        exec.join_async().await;
+                    } else {
+                        exec.abort_async().await;
                     }
+
+                    result
                 })
             },
         )

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -311,7 +311,7 @@ impl<S: SourceTrait> Runtime<S> {
         match stop_ty {
             StopType::Signal(Ok(Some(s))) => {
                 tracing::warn!("{s:?} received, shutting down...");
-                Self::stop_buffer(buffer).await;
+                Self::force_stop_buffer(buffer).await;
                 Ok(())
             },
             StopType::Signal(Ok(None)) => Err(std::io::Error::new(
@@ -324,7 +324,7 @@ impl<S: SourceTrait> Runtime<S> {
             StopType::SourceExit(Ok(status)) => match status {
                 SourceExitStatus::ReceiverDropped => {
                     tracing::info!("Source stopped: receiver dropped (shutdown)");
-                    Self::stop_buffer(buffer).await;
+                    Self::force_stop_buffer(buffer).await;
                     Ok(())
                 },
                 SourceExitStatus::Completed => {
@@ -353,7 +353,7 @@ impl<S: SourceTrait> Runtime<S> {
         Ok(())
     }
 
-    async fn stop_buffer(buffer: buffer::Buffer) {
+    async fn force_stop_buffer(buffer: buffer::Buffer) {
         match buffer.join().await {
             Err(e) => tracing::warn!(err = %Chain(&e), "Error stopping runtime buffer"),
             Ok(c) => c.as_unit(),

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -224,7 +224,7 @@ impl<S: SourceTrait> Runtime<S> {
     /// │   (finite src)  (unexpected)        (gRPC)        (other)           │
     /// │        │              │               │              │              │
     /// │        ▼              ▼               ▼              ▼              │
-    /// │      Ok(())      ServerHangup     ServerHangup     Other            │
+    /// │   drain -> Ok    ServerHangup     ServerHangup     Other            │
     /// │                                                                     │
     /// │    ┌──────────────────────────────────────────────────────────┐     │
     /// │    │ ReceiverDropped: defensive only - normally unreachable   │     │
@@ -308,7 +308,7 @@ impl<S: SourceTrait> Runtime<S> {
             status = status_rx => StopType::SourceExit(status),
         };
 
-        let should_stop_buffer = !matches!(stop_ty, StopType::Buffer(..));
+        let mut should_stop_buffer = !matches!(stop_ty, StopType::Buffer(..));
 
         match stop_ty {
             StopType::Signal(Ok(Some(s))) => {
@@ -328,8 +328,9 @@ impl<S: SourceTrait> Runtime<S> {
                     Ok(())
                 },
                 SourceExitStatus::Completed => {
-                    tracing::info!("Source completed successfully");
-                    Ok(())
+                    tracing::info!("Source completed successfully; draining runtime buffer");
+                    should_stop_buffer = false;
+                    buffer.wait_for_stop().await
                 },
                 SourceExitStatus::StreamEnded => {
                     tracing::warn!("Source stopped: stream ended unexpectedly");

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -308,11 +308,10 @@ impl<S: SourceTrait> Runtime<S> {
             status = status_rx => StopType::SourceExit(status),
         };
 
-        let mut should_stop_buffer = !matches!(stop_ty, StopType::Buffer(..));
-
         match stop_ty {
             StopType::Signal(Ok(Some(s))) => {
                 tracing::warn!("{s:?} received, shutting down...");
+                Self::stop_buffer(buffer).await;
                 Ok(())
             },
             StopType::Signal(Ok(None)) => Err(std::io::Error::new(
@@ -325,11 +324,11 @@ impl<S: SourceTrait> Runtime<S> {
             StopType::SourceExit(Ok(status)) => match status {
                 SourceExitStatus::ReceiverDropped => {
                     tracing::info!("Source stopped: receiver dropped (shutdown)");
+                    Self::stop_buffer(buffer).await;
                     Ok(())
                 },
                 SourceExitStatus::Completed => {
                     tracing::info!("Source completed successfully; draining runtime buffer");
-                    should_stop_buffer = false;
                     buffer.wait_for_stop().await
                 },
                 SourceExitStatus::StreamEnded => {
@@ -350,10 +349,6 @@ impl<S: SourceTrait> Runtime<S> {
                 Err(Error::ClientHangup)
             },
         }?;
-
-        if should_stop_buffer {
-            Self::stop_buffer(buffer).await;
-        }
 
         Ok(())
     }

--- a/crates/runtime/src/runtime_tests.rs
+++ b/crates/runtime/src/runtime_tests.rs
@@ -1,13 +1,21 @@
-use std::time::Duration;
+use std::{
+    borrow::Cow,
+    sync::atomic::{AtomicUsize, Ordering},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use tokio::sync::{mpsc::Sender, oneshot};
-use yellowstone_grpc_proto::{geyser::SubscribeUpdate, tonic};
+use yellowstone_grpc_proto::{
+    geyser::{subscribe_update::UpdateOneof, SlotStatus, SubscribeUpdate, SubscribeUpdateSlot},
+    tonic,
+};
+use yellowstone_vixen_core::{ParseResult, Parser, Prefilter, SlotUpdate};
 
 use crate::{
     config::{BufferConfig, NullConfig, VixenConfig},
     sources::{SourceExitStatus, SourceTrait},
-    Error, Runtime,
+    Error, Handler, Pipeline, Runtime,
 };
 
 // ========== Test helpers ==========
@@ -51,6 +59,22 @@ fn make_ping_update() -> SubscribeUpdate {
                 yellowstone_grpc_proto::geyser::SubscribeUpdatePing {},
             ),
         ),
+        created_at: None,
+    }
+}
+
+const TEST_SLOT_FILTER: &str = "test::SlowSlotParser";
+static SLOW_SLOT_HANDLED: AtomicUsize = AtomicUsize::new(0);
+
+fn make_slot_update(slot: u64) -> SubscribeUpdate {
+    SubscribeUpdate {
+        filters: vec![TEST_SLOT_FILTER.to_string()],
+        update_oneof: Some(UpdateOneof::Slot(SubscribeUpdateSlot {
+            slot,
+            parent: Some(slot.saturating_sub(1)),
+            status: SlotStatus::SlotProcessed as i32,
+            dead_error: None,
+        })),
         created_at: None,
     }
 }
@@ -299,6 +323,66 @@ impl SourceTrait for MockStreamEndWithUpdatesSource {
     }
 }
 
+#[derive(Debug)]
+struct MockCompletedWithUpdatesSource {
+    updates_to_send: u64,
+}
+
+#[async_trait]
+impl SourceTrait for MockCompletedWithUpdatesSource {
+    type Config = NullConfig;
+
+    fn new(_: NullConfig, _: vixen_core::Filters) -> Self { Self { updates_to_send: 3 } }
+
+    async fn connect(
+        &self,
+        tx: Sender<Result<SubscribeUpdate, tonic::Status>>,
+        status_tx: oneshot::Sender<SourceExitStatus>,
+    ) -> Result<(), Error> {
+        wait_for_runtime_ready().await;
+
+        for slot in 0..self.updates_to_send {
+            if tx.send(Ok(make_slot_update(slot))).await.is_err() {
+                signal_receiver_dropped(status_tx);
+                return Ok(());
+            }
+        }
+
+        signal_completed(status_tx);
+        drop(tx);
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SlowSlotParser;
+
+impl Parser for SlowSlotParser {
+    type Input = SlotUpdate;
+    type Output = SlotUpdate;
+
+    fn id(&self) -> Cow<'static, str> { TEST_SLOT_FILTER.into() }
+
+    fn prefilter(&self) -> Prefilter { Prefilter::default() }
+
+    async fn parse(&self, value: &Self::Input) -> ParseResult<Self::Output> { Ok(value.clone()) }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SlowSlotHandler;
+
+impl Handler<SlotUpdate, SlotUpdate> for SlowSlotHandler {
+    async fn handle(
+        &self,
+        _value: &SlotUpdate,
+        _raw_event: &SlotUpdate,
+    ) -> crate::HandlerResult<()> {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        SLOW_SLOT_HANDLED.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
 // ========== Integration tests ==========
 
 #[tokio::test]
@@ -348,6 +432,23 @@ async fn test_stream_end_after_updates_returns_error() {
         .unwrap();
 
     assert_server_hangup(runtime.try_run_async().await);
+}
+
+#[tokio::test]
+async fn test_completed_source_drains_buffered_updates_before_returning() {
+    SLOW_SLOT_HANDLED.store(0, Ordering::Relaxed);
+
+    let runtime = Runtime::<MockCompletedWithUpdatesSource>::builder()
+        .slot(Pipeline::new(SlowSlotParser, [SlowSlotHandler]))
+        .try_build(default_test_config())
+        .unwrap();
+
+    assert!(runtime.try_run_async().await.is_ok());
+    assert_eq!(
+        SLOW_SLOT_HANDLED.load(Ordering::Relaxed),
+        3,
+        "runtime must wait for buffered slot handlers after finite source completion"
+    );
 }
 
 // ========== Unit tests for SourceExitStatus ==========

--- a/examples/jetstreamer/src/main.rs
+++ b/examples/jetstreamer/src/main.rs
@@ -180,6 +180,7 @@ fn main() -> Result<()> {
         network: "mainnet".to_string(),
         compact_index_base_url: "https://files.old-faithful.net".to_string(),
         network_capacity_mb: 100000,
+        possible_leader_skipped_tx: None,
     };
 
     // SAFETY: Called from main() before the Tokio runtime is created.


### PR DESCRIPTION
Runtime:
- fix: end of stream was not draining existing channels before ending

Kafka sink:
- feat: add tx_index in transaction message headers (indicative value)

Jetstreamer:
- fix: use end slot with same semantics as firehose
- feat: add a channel to handle the possible leader skipped