### PR TITLE
core: add InstructionUpdate::direct_log_messages() (#186)

### DIFF
--- a/crates/core/src/instruction.rs
+++ b/crates/core/src/instruction.rs
@@ -248,6 +248,53 @@ impl InstructionUpdate {
     #[must_use]
     pub fn log_messages(&self) -> &[String] { &self.shared.log_messages[self.log_range.clone()] }
 
+    /// Returns the log messages emitted *directly* by this instruction's
+    /// program, excluding lines emitted while an inner CPI is on top of the
+    /// invocation stack.
+    ///
+    /// Unlike [`log_messages`](Self::log_messages), which yields every line
+    /// inside this instruction's `invoke`/`success` window (including nested
+    /// CPI logs), this iterator skips any line that occurs while a deeper
+    /// `Program ... invoke [N+1]` is active.
+    ///
+    /// The opening `Program <id> invoke [N]` and closing
+    /// `Program <id> success`/`failed:` lines for this instruction are
+    /// included; the lines between them are filtered to depth-0 only.
+    ///
+    /// Example output for an outer Raydium ix that CPIs to the token program:
+    ///
+    /// ```text,ignore
+    /// Program RAY invoke [1]
+    /// Program log: ray_log: swap-base-in
+    /// Program log: ray_log: swap done
+    /// Program RAY success
+    /// ```
+    ///
+    /// (Token-program lines emitted at depth 2 are skipped.)
+    pub fn direct_log_messages(&self) -> impl Iterator<Item = &str> {
+        use crate::log_messages::{classify_log_line, LogLineKind};
+
+        let lines = self.log_messages();
+        let mut depth: u32 = 0;
+
+        lines.iter().filter_map(move |line| {
+            match classify_log_line(line) {
+                LogLineKind::Invoke => {
+                    depth += 1;
+                    // Only the outermost invoke (this instruction's own) is at
+                    // depth 1 after the increment; deeper invokes are skipped.
+                    (depth == 1).then_some(line.as_str())
+                }
+                LogLineKind::Close => {
+                    let was_outer = depth == 1;
+                    depth = depth.saturating_sub(1);
+                    was_outer.then_some(line.as_str())
+                }
+                LogLineKind::Other => (depth == 1).then_some(line.as_str()),
+            }
+        })
+    }
+
     /// Build instruction updates from a transaction update.
     ///
     /// # Errors

--- a/crates/core/src/instruction.rs
+++ b/crates/core/src/instruction.rs
@@ -284,12 +284,12 @@ impl InstructionUpdate {
                     // Only the outermost invoke (this instruction's own) is at
                     // depth 1 after the increment; deeper invokes are skipped.
                     (depth == 1).then_some(line.as_str())
-                }
+                },
                 LogLineKind::Close => {
                     let was_outer = depth == 1;
                     depth = depth.saturating_sub(1);
                     was_outer.then_some(line.as_str())
-                }
+                },
                 LogLineKind::Other => (depth == 1).then_some(line.as_str()),
             }
         })

--- a/crates/core/src/log_messages.rs
+++ b/crates/core/src/log_messages.rs
@@ -117,15 +117,15 @@ fn assign_logs_recursive(logs: &[String], start: usize, ix: &mut InstructionUpda
                     continue;
                 }
                 depth += 1;
-            }
+            },
             LogLineKind::Close => {
                 depth -= 1;
                 if depth == 0 {
                     ix.log_range = invoke_pos..(pos + 1);
                     return pos + 1;
                 }
-            }
-            LogLineKind::Other => {}
+            },
+            LogLineKind::Other => {},
         }
 
         pos += 1;
@@ -175,7 +175,7 @@ pub fn split_logs_by_outer_ix(logs: &[String]) -> Vec<Vec<String>> {
             match kind {
                 LogLineKind::Invoke => depth += 1,
                 LogLineKind::Close => depth -= 1,
-                LogLineKind::Other => {}
+                LogLineKind::Other => {},
             }
 
             current.push(line.clone());
@@ -419,14 +419,11 @@ mod tests {
         assign_log_messages(&shared.log_messages, &mut outer);
 
         let direct: Vec<&str> = outer[0].direct_log_messages().collect();
-        assert_eq!(
-            direct,
-            vec![
-                "Program RAY invoke [1]",
-                "Program log: ray_log: recovering",
-                "Program RAY success",
-            ]
-        );
+        assert_eq!(direct, vec![
+            "Program RAY invoke [1]",
+            "Program log: ray_log: recovering",
+            "Program RAY success",
+        ]);
     }
 
     /// Iter 3: when an outer ix has no inner CPIs, `direct_log_messages()`
@@ -520,15 +517,12 @@ mod tests {
         assign_log_messages(&shared.log_messages, &mut outer);
 
         let direct: Vec<&str> = outer[0].direct_log_messages().collect();
-        assert_eq!(
-            direct,
-            vec![
-                "Program A invoke [1]",
-                "Program log: A start",
-                "Program log: A end",
-                "Program A success",
-            ]
-        );
+        assert_eq!(direct, vec![
+            "Program A invoke [1]",
+            "Program log: A start",
+            "Program log: A end",
+            "Program A success",
+        ]);
     }
 
     /// Iter 5: an outer ix's own `Program data:` line is preserved; an inner
@@ -616,14 +610,11 @@ mod tests {
         assign_log_messages(&shared.log_messages, &mut outer);
 
         let direct: Vec<&str> = outer[0].direct_log_messages().collect();
-        assert_eq!(
-            direct,
-            vec![
-                "Program OUTER invoke [1]",
-                "Program return: OUTER 8fo2SxUAAAA=",
-                "Program OUTER success",
-            ]
-        );
+        assert_eq!(direct, vec![
+            "Program OUTER invoke [1]",
+            "Program return: OUTER 8fo2SxUAAAA=",
+            "Program OUTER success",
+        ]);
     }
 
     /// Iter 7: adversarial input — a `Program log:` payload that contains
@@ -722,21 +713,48 @@ mod tests {
     #[test]
     fn classify_log_line_covers_all_shapes() {
         // Real invokes
-        assert_eq!(classify_log_line("Program ABC invoke [1]"), LogLineKind::Invoke);
-        assert_eq!(classify_log_line("Program ABC invoke [2]"), LogLineKind::Invoke);
-        assert_eq!(classify_log_line("Program ABC invoke [99]"), LogLineKind::Invoke);
+        assert_eq!(
+            classify_log_line("Program ABC invoke [1]"),
+            LogLineKind::Invoke
+        );
+        assert_eq!(
+            classify_log_line("Program ABC invoke [2]"),
+            LogLineKind::Invoke
+        );
+        assert_eq!(
+            classify_log_line("Program ABC invoke [99]"),
+            LogLineKind::Invoke
+        );
 
         // Real closes
         assert_eq!(classify_log_line("Program ABC success"), LogLineKind::Close);
-        assert_eq!(classify_log_line("Program ABC failed: custom error: 0x1"), LogLineKind::Close);
+        assert_eq!(
+            classify_log_line("Program ABC failed: custom error: 0x1"),
+            LogLineKind::Close
+        );
 
         // Runtime-tagged lines are Other regardless of payload
         assert_eq!(classify_log_line("Program log: hello"), LogLineKind::Other);
-        assert_eq!(classify_log_line("Program log: invoke [2]"), LogLineKind::Other);
-        assert_eq!(classify_log_line("Program log: success"), LogLineKind::Other);
-        assert_eq!(classify_log_line("Program log: failed: nope"), LogLineKind::Other);
-        assert_eq!(classify_log_line("Program data: BASE64=="), LogLineKind::Other);
-        assert_eq!(classify_log_line("Program return: ABC abc="), LogLineKind::Other);
+        assert_eq!(
+            classify_log_line("Program log: invoke [2]"),
+            LogLineKind::Other
+        );
+        assert_eq!(
+            classify_log_line("Program log: success"),
+            LogLineKind::Other
+        );
+        assert_eq!(
+            classify_log_line("Program log: failed: nope"),
+            LogLineKind::Other
+        );
+        assert_eq!(
+            classify_log_line("Program data: BASE64=="),
+            LogLineKind::Other
+        );
+        assert_eq!(
+            classify_log_line("Program return: ABC abc="),
+            LogLineKind::Other
+        );
 
         // Compute-units consumption line is Other (not a close)
         assert_eq!(
@@ -750,8 +768,17 @@ mod tests {
         assert_eq!(classify_log_line("Program "), LogLineKind::Other);
 
         // Malformed invoke variants are Other
-        assert_eq!(classify_log_line("Program ABC invoke []"), LogLineKind::Other);
-        assert_eq!(classify_log_line("Program ABC invoke [abc]"), LogLineKind::Other);
-        assert_eq!(classify_log_line("Program ABC invoke 1"), LogLineKind::Other);
+        assert_eq!(
+            classify_log_line("Program ABC invoke []"),
+            LogLineKind::Other
+        );
+        assert_eq!(
+            classify_log_line("Program ABC invoke [abc]"),
+            LogLineKind::Other
+        );
+        assert_eq!(
+            classify_log_line("Program ABC invoke 1"),
+            LogLineKind::Other
+        );
     }
 }

--- a/crates/core/src/log_messages.rs
+++ b/crates/core/src/log_messages.rs
@@ -3,6 +3,65 @@
 
 use super::instruction::InstructionUpdate;
 
+/// Classification of a single Solana transaction log line.
+///
+/// Solana's runtime emits log lines in three structural shapes the
+/// instruction-attribution code cares about:
+///
+/// - `Program <pubkey> invoke [<n>]` — opens a program invocation at depth `n`.
+/// - `Program <pubkey> success` / `Program <pubkey> failed: <reason>` — closes one.
+/// - everything else (`Program log: ...`, `Program data: ...`,
+///   `Program return: ...`, `Program <pubkey> consumed N of M compute units`,
+///   user payloads, etc.) — depth is unchanged.
+///
+/// Classification is structural, not substring-based: a `Program log:` payload
+/// containing the literal text `" invoke [2]"` is `Other`, not `Invoke`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum LogLineKind {
+    /// `Program <pubkey> invoke [<n>]`
+    Invoke,
+    /// `Program <pubkey> success` or `Program <pubkey> failed: ...`
+    Close,
+    /// Anything else.
+    Other,
+}
+
+/// Classify a Solana log line.
+///
+/// A line is only an `Invoke` or `Close` if its second whitespace-separated
+/// token is a real pubkey-shaped string — i.e. *not* one of the reserved
+/// runtime tags `log:`, `data:`, `return:`. This rejects adversarial
+/// `Program log: ... invoke [2]` payloads from being misclassified.
+pub(crate) fn classify_log_line(line: &str) -> LogLineKind {
+    let Some(rest) = line.strip_prefix("Program ") else {
+        return LogLineKind::Other;
+    };
+
+    // Second token must be a pubkey, not a runtime-reserved tag.
+    let Some((second, tail)) = rest.split_once(' ') else {
+        return LogLineKind::Other;
+    };
+    if matches!(second, "log:" | "data:" | "return:") {
+        return LogLineKind::Other;
+    }
+
+    // Invoke shape: `invoke [<digits>]`.
+    if let Some(after_invoke) = tail.strip_prefix("invoke [")
+        && let Some(digits) = after_invoke.split(']').next()
+        && !digits.is_empty()
+        && digits.chars().all(|c| c.is_ascii_digit())
+    {
+        return LogLineKind::Invoke;
+    }
+
+    // Close shape: literal `success` or starts with `failed:`.
+    if tail == "success" || tail.starts_with("failed:") {
+        return LogLineKind::Close;
+    }
+
+    LogLineKind::Other
+}
+
 ///
 /// Walk the transaction log messages and assign each instruction's log slice.
 ///
@@ -48,31 +107,25 @@ fn assign_logs_recursive(logs: &[String], start: usize, ix: &mut InstructionUpda
     let mut inner_idx = 0;
 
     while pos < logs.len() && depth > 0 {
-        let line = &logs[pos];
-
-        if line.starts_with("Program ") {
-            if line.contains(" invoke [") {
+        match classify_log_line(&logs[pos]) {
+            LogLineKind::Invoke => {
                 // Entering a nested instruction — assign logs to the
                 // corresponding inner instruction if one exists.
                 if inner_idx < ix.inner.len() {
                     pos = assign_logs_recursive(logs, pos, &mut ix.inner[inner_idx]);
-
                     inner_idx += 1;
-
                     continue;
                 }
-
                 depth += 1;
-            } else if line.ends_with(" success") || line.contains(" failed:") {
+            }
+            LogLineKind::Close => {
                 depth -= 1;
-
                 if depth == 0 {
-                    // This is the closing line for the current instruction.
                     ix.log_range = invoke_pos..(pos + 1);
-
                     return pos + 1;
                 }
             }
+            LogLineKind::Other => {}
         }
 
         pos += 1;
@@ -84,12 +137,13 @@ fn assign_logs_recursive(logs: &[String], start: usize, ix: &mut InstructionUpda
     pos
 }
 
-/// Find the next `Program ... invoke [N]` line at or after `start`.
+/// Find the next real `Program <pubkey> invoke [N]` line at or after `start`,
+/// ignoring adversarial `Program log:` payloads that contain that substring.
 fn find_invoke(logs: &[String], start: usize) -> Option<usize> {
     logs.iter()
         .enumerate()
         .skip(start)
-        .find(|(_, line)| line.starts_with("Program ") && line.contains(" invoke ["))
+        .find(|(_, line)| classify_log_line(line) == LogLineKind::Invoke)
         .map(|(i, _)| i)
 }
 
@@ -106,7 +160,10 @@ pub fn split_logs_by_outer_ix(logs: &[String]) -> Vec<Vec<String>> {
     let mut depth: u32 = 0;
 
     for line in logs {
-        if line.starts_with("Program ") && line.contains(" invoke [1]") && depth == 0 {
+        let kind = classify_log_line(line);
+        let is_outer_invoke = matches!(kind, LogLineKind::Invoke) && line.contains(" invoke [1]");
+
+        if is_outer_invoke && depth == 0 {
             if !current.is_empty() {
                 result.push(std::mem::take(&mut current));
             }
@@ -115,12 +172,10 @@ pub fn split_logs_by_outer_ix(logs: &[String]) -> Vec<Vec<String>> {
 
             current.push(line.clone());
         } else if depth > 0 {
-            if line.starts_with("Program ") && line.contains(" invoke [") {
-                depth += 1;
-            } else if line.starts_with("Program ")
-                && (line.ends_with(" success") || line.contains(" failed:"))
-            {
-                depth -= 1;
+            match kind {
+                LogLineKind::Invoke => depth += 1,
+                LogLineKind::Close => depth -= 1,
+                LogLineKind::Other => {}
             }
 
             current.push(line.clone());
@@ -246,5 +301,457 @@ mod tests {
 
         assert_eq!(outer[1].log_messages().len(), 3);
         assert_eq!(outer[1].log_messages()[1], "Program log: second");
+    }
+
+    /// Regression for issue #186 / PR #187 follow-up: a handler asking for
+    /// "logs my program emitted" must not see lines from inner CPI invocations.
+    ///
+    /// `log_messages()` returns the full nested range (invoke through success
+    /// inclusive, including inner CPI lines). `direct_log_messages()` returns
+    /// only the lines emitted while *this* program is at the top of the
+    /// invocation stack — the CPI-aware view that DEX handlers (Raydium,
+    /// Boop, Pump) need to scrape `Program log:` trade results without
+    /// pulling in token-program transfer logs.
+    #[test]
+    fn direct_log_messages_excludes_inner_cpi_lines() {
+        let logs: Vec<String> = vec![
+            "Program RAY invoke [1]",
+            "Program log: ray_log: swap-base-in",
+            "Program TOKEN invoke [2]",
+            "Program log: Instruction: Transfer",
+            "Program TOKEN success",
+            "Program log: ray_log: swap done",
+            "Program RAY success",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let shared = Arc::new(InstructionShared {
+            log_messages: logs.clone(),
+            ..InstructionShared::default()
+        });
+
+        let mut outer = vec![InstructionUpdate {
+            program: KeyBytes::new([1; 32]),
+            accounts: vec![],
+            data: vec![],
+            shared: Arc::clone(&shared),
+            inner: vec![InstructionUpdate {
+                program: KeyBytes::new([2; 32]),
+                accounts: vec![],
+                data: vec![],
+                shared: Arc::clone(&shared),
+                inner: vec![],
+                path: Path::from(vec![0, 0]),
+                log_range: 0..0,
+            }],
+            path: Path::new_single(0),
+            log_range: 0..0,
+        }];
+
+        assign_log_messages(&shared.log_messages, &mut outer);
+
+        let direct: Vec<&str> = outer[0].direct_log_messages().collect();
+
+        assert_eq!(
+            direct,
+            vec![
+                "Program RAY invoke [1]",
+                "Program log: ray_log: swap-base-in",
+                "Program log: ray_log: swap done",
+                "Program RAY success",
+            ],
+            "direct_log_messages must skip inner CPI lines"
+        );
+
+        let inner_direct: Vec<&str> = outer[0].inner[0].direct_log_messages().collect();
+        assert_eq!(
+            inner_direct,
+            vec![
+                "Program TOKEN invoke [2]",
+                "Program log: Instruction: Transfer",
+                "Program TOKEN success",
+            ],
+            "inner ix direct_log_messages contains only its own lines"
+        );
+    }
+
+    /// Edge case: inner CPI ends with `failed:` rather than `success`. The
+    /// closing line still pops depth, so the outer program's trailing line
+    /// must be visible.
+    #[test]
+    fn direct_log_messages_handles_failed_inner_cpi() {
+        let logs: Vec<String> = vec![
+            "Program RAY invoke [1]",
+            "Program TOKEN invoke [2]",
+            "Program TOKEN failed: custom error",
+            "Program log: ray_log: recovering",
+            "Program RAY success",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let shared = Arc::new(InstructionShared {
+            log_messages: logs.clone(),
+            ..InstructionShared::default()
+        });
+
+        let mut outer = vec![InstructionUpdate {
+            program: KeyBytes::new([1; 32]),
+            accounts: vec![],
+            data: vec![],
+            shared: Arc::clone(&shared),
+            inner: vec![InstructionUpdate {
+                program: KeyBytes::new([2; 32]),
+                accounts: vec![],
+                data: vec![],
+                shared: Arc::clone(&shared),
+                inner: vec![],
+                path: Path::from(vec![0, 0]),
+                log_range: 0..0,
+            }],
+            path: Path::new_single(0),
+            log_range: 0..0,
+        }];
+
+        assign_log_messages(&shared.log_messages, &mut outer);
+
+        let direct: Vec<&str> = outer[0].direct_log_messages().collect();
+        assert_eq!(
+            direct,
+            vec![
+                "Program RAY invoke [1]",
+                "Program log: ray_log: recovering",
+                "Program RAY success",
+            ]
+        );
+    }
+
+    /// Iter 3: when an outer ix has no inner CPIs, `direct_log_messages()`
+    /// must equal `log_messages()` exactly.
+    #[test]
+    fn direct_log_messages_flat_ix_equals_log_messages() {
+        let logs: Vec<String> = vec![
+            "Program SOLO invoke [1]",
+            "Program log: nothing nested here",
+            "Program log: another line",
+            "Program SOLO success",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let shared = Arc::new(InstructionShared {
+            log_messages: logs.clone(),
+            ..InstructionShared::default()
+        });
+
+        let mut outer = vec![InstructionUpdate {
+            program: KeyBytes::new([1; 32]),
+            accounts: vec![],
+            data: vec![],
+            shared: Arc::clone(&shared),
+            inner: vec![],
+            path: Path::new_single(0),
+            log_range: 0..0,
+        }];
+
+        assign_log_messages(&shared.log_messages, &mut outer);
+
+        let full: Vec<&str> = outer[0].log_messages().iter().map(String::as_str).collect();
+        let direct: Vec<&str> = outer[0].direct_log_messages().collect();
+        assert_eq!(direct, full, "flat ix: direct must equal full");
+    }
+
+    /// Iter 4: A → B → C three-level CPI. Outer A's direct view must skip
+    /// every line emitted while B or C are on the stack.
+    #[test]
+    fn direct_log_messages_filters_three_deep_cpi() {
+        let logs: Vec<String> = vec![
+            "Program A invoke [1]",
+            "Program log: A start",
+            "Program B invoke [2]",
+            "Program log: B start",
+            "Program C invoke [3]",
+            "Program log: C only",
+            "Program C success",
+            "Program log: B middle",
+            "Program B success",
+            "Program log: A end",
+            "Program A success",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let shared = Arc::new(InstructionShared {
+            log_messages: logs.clone(),
+            ..InstructionShared::default()
+        });
+
+        let mut outer = vec![InstructionUpdate {
+            program: KeyBytes::new([1; 32]),
+            accounts: vec![],
+            data: vec![],
+            shared: Arc::clone(&shared),
+            inner: vec![InstructionUpdate {
+                program: KeyBytes::new([2; 32]),
+                accounts: vec![],
+                data: vec![],
+                shared: Arc::clone(&shared),
+                inner: vec![InstructionUpdate {
+                    program: KeyBytes::new([3; 32]),
+                    accounts: vec![],
+                    data: vec![],
+                    shared: Arc::clone(&shared),
+                    inner: vec![],
+                    path: Path::from(vec![0, 0, 0]),
+                    log_range: 0..0,
+                }],
+                path: Path::from(vec![0, 0]),
+                log_range: 0..0,
+            }],
+            path: Path::new_single(0),
+            log_range: 0..0,
+        }];
+
+        assign_log_messages(&shared.log_messages, &mut outer);
+
+        let direct: Vec<&str> = outer[0].direct_log_messages().collect();
+        assert_eq!(
+            direct,
+            vec![
+                "Program A invoke [1]",
+                "Program log: A start",
+                "Program log: A end",
+                "Program A success",
+            ]
+        );
+    }
+
+    /// Iter 5: an outer ix's own `Program data:` line is preserved; an inner
+    /// CPI's `Program data:` line is dropped. This is the core guarantee for
+    /// Anchor-event handlers that decode payloads from depth-1 lines.
+    #[test]
+    fn direct_log_messages_keeps_own_program_data_drops_inner() {
+        let logs: Vec<String> = vec![
+            "Program OUTER invoke [1]",
+            "Program data: OUTER_PAYLOAD_BASE64==",
+            "Program INNER invoke [2]",
+            "Program data: INNER_PAYLOAD_BASE64==",
+            "Program INNER success",
+            "Program OUTER success",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let shared = Arc::new(InstructionShared {
+            log_messages: logs.clone(),
+            ..InstructionShared::default()
+        });
+
+        let mut outer = vec![InstructionUpdate {
+            program: KeyBytes::new([1; 32]),
+            accounts: vec![],
+            data: vec![],
+            shared: Arc::clone(&shared),
+            inner: vec![InstructionUpdate {
+                program: KeyBytes::new([2; 32]),
+                accounts: vec![],
+                data: vec![],
+                shared: Arc::clone(&shared),
+                inner: vec![],
+                path: Path::from(vec![0, 0]),
+                log_range: 0..0,
+            }],
+            path: Path::new_single(0),
+            log_range: 0..0,
+        }];
+
+        assign_log_messages(&shared.log_messages, &mut outer);
+
+        let direct: Vec<&str> = outer[0].direct_log_messages().collect();
+        assert!(
+            direct.contains(&"Program data: OUTER_PAYLOAD_BASE64=="),
+            "outer Program data: must be preserved"
+        );
+        assert!(
+            !direct.contains(&"Program data: INNER_PAYLOAD_BASE64=="),
+            "inner Program data: must be filtered out"
+        );
+    }
+
+    /// Iter 6: `Program return: <id> <data>` lines (real txns place these
+    /// just before `success`) are at depth 1 and must be kept. They aren't
+    /// invokes and aren't closes.
+    #[test]
+    fn direct_log_messages_keeps_program_return() {
+        let logs: Vec<String> = vec![
+            "Program OUTER invoke [1]",
+            "Program return: OUTER 8fo2SxUAAAA=",
+            "Program OUTER success",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let shared = Arc::new(InstructionShared {
+            log_messages: logs.clone(),
+            ..InstructionShared::default()
+        });
+
+        let mut outer = vec![InstructionUpdate {
+            program: KeyBytes::new([1; 32]),
+            accounts: vec![],
+            data: vec![],
+            shared: Arc::clone(&shared),
+            inner: vec![],
+            path: Path::new_single(0),
+            log_range: 0..0,
+        }];
+
+        assign_log_messages(&shared.log_messages, &mut outer);
+
+        let direct: Vec<&str> = outer[0].direct_log_messages().collect();
+        assert_eq!(
+            direct,
+            vec![
+                "Program OUTER invoke [1]",
+                "Program return: OUTER 8fo2SxUAAAA=",
+                "Program OUTER success",
+            ]
+        );
+    }
+
+    /// Iter 7: adversarial input — a `Program log:` payload that contains
+    /// the substring `" invoke ["`. The depth tracker must not be fooled
+    /// by user-supplied log content.
+    #[test]
+    fn direct_log_messages_ignores_invoke_in_program_log_payload() {
+        let logs: Vec<String> = vec![
+            "Program OUTER invoke [1]",
+            "Program log: before",
+            "Program log: this looks like invoke [2] but is not",
+            "Program log: after",
+            "Program OUTER success",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let shared = Arc::new(InstructionShared {
+            log_messages: logs.clone(),
+            ..InstructionShared::default()
+        });
+
+        let mut outer = vec![InstructionUpdate {
+            program: KeyBytes::new([1; 32]),
+            accounts: vec![],
+            data: vec![],
+            shared: Arc::clone(&shared),
+            inner: vec![],
+            path: Path::new_single(0),
+            log_range: 0..0,
+        }];
+
+        assign_log_messages(&shared.log_messages, &mut outer);
+
+        let direct: Vec<&str> = outer[0].direct_log_messages().collect();
+        assert_eq!(
+            direct,
+            vec![
+                "Program OUTER invoke [1]",
+                "Program log: before",
+                "Program log: this looks like invoke [2] but is not",
+                "Program log: after",
+                "Program OUTER success",
+            ],
+            "Program log: payload must not be misclassified as an invoke"
+        );
+    }
+
+    /// Iter 9: same class of bug — `Program log:` payload containing
+    /// `" success"` must not be misclassified as a close.
+    #[test]
+    fn direct_log_messages_ignores_success_in_program_log_payload() {
+        let logs: Vec<String> = vec![
+            "Program OUTER invoke [1]",
+            "Program log: oh what a success",
+            "Program log: still going",
+            "Program OUTER success",
+        ]
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+        let shared = Arc::new(InstructionShared {
+            log_messages: logs.clone(),
+            ..InstructionShared::default()
+        });
+
+        let mut outer = vec![InstructionUpdate {
+            program: KeyBytes::new([1; 32]),
+            accounts: vec![],
+            data: vec![],
+            shared: Arc::clone(&shared),
+            inner: vec![],
+            path: Path::new_single(0),
+            log_range: 0..0,
+        }];
+
+        assign_log_messages(&shared.log_messages, &mut outer);
+
+        let direct: Vec<&str> = outer[0].direct_log_messages().collect();
+        assert_eq!(
+            direct,
+            vec![
+                "Program OUTER invoke [1]",
+                "Program log: oh what a success",
+                "Program log: still going",
+                "Program OUTER success",
+            ],
+            "Program log: payload must not be misclassified as a close"
+        );
+    }
+
+    /// Direct unit coverage of the line classifier. Pins the structural
+    /// rules independent of the higher-level filtering logic.
+    #[test]
+    fn classify_log_line_covers_all_shapes() {
+        // Real invokes
+        assert_eq!(classify_log_line("Program ABC invoke [1]"), LogLineKind::Invoke);
+        assert_eq!(classify_log_line("Program ABC invoke [2]"), LogLineKind::Invoke);
+        assert_eq!(classify_log_line("Program ABC invoke [99]"), LogLineKind::Invoke);
+
+        // Real closes
+        assert_eq!(classify_log_line("Program ABC success"), LogLineKind::Close);
+        assert_eq!(classify_log_line("Program ABC failed: custom error: 0x1"), LogLineKind::Close);
+
+        // Runtime-tagged lines are Other regardless of payload
+        assert_eq!(classify_log_line("Program log: hello"), LogLineKind::Other);
+        assert_eq!(classify_log_line("Program log: invoke [2]"), LogLineKind::Other);
+        assert_eq!(classify_log_line("Program log: success"), LogLineKind::Other);
+        assert_eq!(classify_log_line("Program log: failed: nope"), LogLineKind::Other);
+        assert_eq!(classify_log_line("Program data: BASE64=="), LogLineKind::Other);
+        assert_eq!(classify_log_line("Program return: ABC abc="), LogLineKind::Other);
+
+        // Compute-units consumption line is Other (not a close)
+        assert_eq!(
+            classify_log_line("Program ABC consumed 1234 of 200000 compute units"),
+            LogLineKind::Other,
+        );
+
+        // Non-Program lines are Other
+        assert_eq!(classify_log_line("just a random log"), LogLineKind::Other);
+        assert_eq!(classify_log_line(""), LogLineKind::Other);
+        assert_eq!(classify_log_line("Program "), LogLineKind::Other);
+
+        // Malformed invoke variants are Other
+        assert_eq!(classify_log_line("Program ABC invoke []"), LogLineKind::Other);
+        assert_eq!(classify_log_line("Program ABC invoke [abc]"), LogLineKind::Other);
+        assert_eq!(classify_log_line("Program ABC invoke 1"), LogLineKind::Other);
     }
 }


### PR DESCRIPTION
## Summary

Adds a CPI-aware iterator that yields only the log lines emitted while this instruction's program is at the top of the invocation stack — built on the existing `log_range` infrastructure from #236, instead of re-introducing a redundant `log_indices: Vec<usize>` field.

Also extracts a `LogLineKind` classifier and routes `assign_logs_recursive`, `find_invoke`, and `split_logs_by_outer_ix` through it. This fixes a preexisting bug where `Program log:` payloads containing `" invoke ["` or `" success"` substrings were misclassified as real invokes/closes, truncating `log_range`.

## Why this shape

Per @kespinola's review on #187: rather than add `log_indices: Vec<usize>` (duplicates the merged `log_range: Range<usize>`), this builds the requested CPI-aware view as a single additive method on `InstructionUpdate`. No struct field changes, no breaking API.

## Usage

```rust
// Outer Raydium ix that CPIs into the token program for transfers.
async fn handle(&self, ix: &InstructionUpdate) -> HandlerResult<()> {
    // Old: yields token-program "Instruction: Transfer" lines too.
    let _full = ix.log_messages();

    // New: yields only the lines Raydium emitted directly.
    for line in ix.direct_log_messages() {
        if let Some(payload) = line.strip_prefix("Program log: ray_log: ") {
            // parse Raydium's swap log...
        }
    }
    Ok(())
}
```
- Closes #186
- Supersedes #187