### PR TITLE
fix(block-coordinator): correct 'Clonable' typo in CoordinatorHandle doc

### DIFF
--- a/crates/block-coordinator/src/types.rs
+++ b/crates/block-coordinator/src/types.rs
@@ -236,7 +236,7 @@ pub struct AccountSlot<R> {
     pub failed_account_count: u64,
 }
 
-/// Clonable handle for handlers to send messages to the coordinator.
+/// Cloneable handle for handlers to send messages to the coordinator.
 #[derive(Clone)]
 pub struct CoordinatorHandle<R> {
     tx: tokio::sync::mpsc::Sender<CoordinatorMessage<R>>,


### PR DESCRIPTION
## Summary

- One-line doc-comment typo fix: `Clonable` → `Cloneable` in `CoordinatorHandle` (`crates/block-coordinator/src/types.rs:239`)

## Test plan

- [x] Doc comment only — no behavior change, no tests affected