### PR TITLE
feat(jetstreamer-source): bump jetstreamer 0.2 -> 0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- `yellowstone-vixen-jetstream-source`: bumped `jetstreamer-firehose` and `jetstreamer-utils` from `0.2` to `0.5` to track upstream Anza releases.
+- **Breaking** for downstream struct-literal construction: `JetstreamSourceConfig` gained two new fields, `sequential: bool` (default `false`) and `buffer_window_bytes: Option<u64>` (default `None`), to expose the upstream `sequential` / ripget buffer-window controls. Both are `#[serde(default)]` and have clap defaults, so deserialized and CLI-built configs are unaffected; only direct struct-literal initialization needs updating.
+
 ## [0.5.0] - 2025-09-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,10 +3756,11 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jetstreamer-firehose"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54bc19adb42c467b655ac2a56ae6e144ebd39c020cbb852c3c383652adc100ec"
+checksum = "6e52ad086d65d20d26a24551a802a232dc993b2b7f67bacd608ec4ceb7336e96"
 dependencies = [
+ "ahash 0.8.12",
  "base64 0.22.1",
  "bincode",
  "cid",
@@ -3768,11 +3769,13 @@ dependencies = [
  "dashmap",
  "fnv",
  "futures-util",
+ "libc",
  "log",
  "multihash",
  "once_cell",
  "prost 0.11.9",
  "reqwest 0.12.24",
+ "ripget",
  "rseek",
  "serde",
  "serde_cbor",
@@ -3784,6 +3787,7 @@ dependencies = [
  "solana-hash 3.1.0",
  "solana-ledger",
  "solana-logger",
+ "solana-message 3.0.1",
  "solana-reward-info",
  "solana-rpc",
  "solana-runtime",
@@ -3794,15 +3798,17 @@ dependencies = [
  "solana-transaction-status",
  "thiserror 2.0.17",
  "tokio",
+ "url 2.5.7",
+ "wincode 0.2.5",
  "xxhash-rust",
  "zstd",
 ]
 
 [[package]]
 name = "jetstreamer-utils"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c413b93e384d56432ac80604fdf41282526cfeba7e6d8127b7d34a238ccc11"
+checksum = "8e6507e6c0f73a7e348eb84cb11708bdc4d4219dbed089b9223fecef1f0c1e0d"
 dependencies = [
  "ctrlc",
  "libc",
@@ -6103,6 +6109,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripget"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5430a564aaf6e9413e9ad5f27b629211c0ef7c746bd034714de4e97cb312ef4"
+dependencies = [
+ "clap 4.5.53",
+ "env_logger",
+ "futures-util",
+ "indicatif 0.18.3",
+ "log",
+ "reqwest 0.12.24",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-util 0.7.17",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7792,7 +7815,7 @@ dependencies = [
  "solana-signature 3.1.0",
  "solana-transaction",
  "solana-transaction-error 3.0.0",
- "wincode",
+ "wincode 0.1.2",
 ]
 
 [[package]]
@@ -8511,7 +8534,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "trees",
- "wincode",
+ "wincode 0.1.2",
 ]
 
 [[package]]
@@ -13278,7 +13301,20 @@ dependencies = [
  "quote",
  "solana-short-vec 3.0.0",
  "thiserror 2.0.17",
- "wincode-derive",
+ "wincode-derive 0.1.1",
+]
+
+[[package]]
+name = "wincode"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5cec722a3274e47d1524cbe2cea762f2c19d615bd9d73ada21db9066349d57e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "solana-short-vec 3.0.0",
+ "thiserror 2.0.17",
+ "wincode-derive 0.2.3",
 ]
 
 [[package]]
@@ -13286,6 +13322,18 @@ name = "wincode-derive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a144d1576a6d65f9c80df1d531e12b197057c6f69a6e9d4a183fe61e9f135568"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8961eb04054a1b2e026b5628e24da7e001350249a787e1a85aa961f33dc5f286"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -14048,7 +14096,7 @@ dependencies = [
  "solana-transaction-status",
  "thiserror 1.0.69",
  "tokio",
- "tokio-util 0.7.17",
+ "toml 0.8.23",
  "tracing",
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,8 +97,8 @@ quote = "1"
 zstd = "^0.13.0"
 bytemuck = "^1"
 tokio-util = "0.7"
-jetstreamer-firehose = "0.2"
-jetstreamer-utils = "0.2"
+jetstreamer-firehose = "0.5"
+jetstreamer-utils = "0.5"
 warp = "0.3"
 
 yellowstone-block-machine = { version = "0.4.0" }

--- a/crates/jetstreamer-source/Cargo.toml
+++ b/crates/jetstreamer-source/Cargo.toml
@@ -20,7 +20,6 @@ yellowstone-grpc-client = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 clap = { workspace = true, features = ["derive", "cargo", "wrap_help"] }
 thiserror = { workspace = true }
-tokio-util = { workspace = true }
 prost-types = { workspace = true }
 
 jetstreamer-firehose = { workspace = true }
@@ -37,6 +36,9 @@ solana-transaction-status = { workspace = true }
 solana-runtime = { workspace = true }
 
 bincode = "1.3"
+
+[dev-dependencies]
+toml = { workspace = true }
 
 [features]
 default = []

--- a/crates/jetstreamer-source/src/lib.rs
+++ b/crates/jetstreamer-source/src/lib.rs
@@ -505,7 +505,8 @@ impl SourceTrait for JetstreamSource {
 
         if config.buffer_window_bytes.is_some() && !config.sequential {
             tracing::warn!(
-                "`buffer_window_bytes` is set but `sequential` is false; the value will be ignored by jetstreamer-firehose"
+                "`buffer_window_bytes` is set but `sequential` is false; the value will be \
+                 ignored by jetstreamer-firehose"
             );
         }
 

--- a/crates/jetstreamer-source/src/lib.rs
+++ b/crates/jetstreamer-source/src/lib.rs
@@ -6,8 +6,7 @@ use std::sync::{
 use async_trait::async_trait;
 use futures_util::FutureExt;
 use jetstreamer_firehose::firehose::{firehose, BlockData, OnErrorFn, TransactionData};
-use tokio::sync::{mpsc, mpsc::Sender, oneshot};
-use tokio_util::sync::CancellationToken;
+use tokio::sync::{broadcast, mpsc, mpsc::Sender, oneshot};
 use tracing::{debug, error, info};
 use yellowstone_grpc_proto::{
     geyser::{subscribe_update::UpdateOneof, SubscribeUpdate, SubscribeUpdateBlock},
@@ -395,6 +394,20 @@ pub struct JetstreamSourceConfig {
     #[arg(long, env, default_value = "1000")]
     pub network_capacity_mb: usize,
 
+    /// Sequential mode: single firehose worker thread with parallel ripget
+    /// downloads. Required by upstream for the high-throughput (≥150k TPS)
+    /// path; `threads` then configures ripget range concurrency.
+    #[arg(long, env, default_value = "false")]
+    #[serde(default)]
+    pub sequential: bool,
+
+    /// Ripget hot/cold window size in bytes when `sequential` is enabled.
+    /// Ignored when `sequential` is `false`. `None` uses the upstream
+    /// default (`min(4 GiB, 15% of available RAM)`).
+    #[arg(long, env)]
+    #[serde(default)]
+    pub buffer_window_bytes: Option<u64>,
+
     /// Optional side channel for `PossibleLeaderSkipped` events.
     #[serde(skip)]
     #[arg(skip)]
@@ -470,6 +483,10 @@ impl SourceTrait for JetstreamSource {
 
     fn new(config: Self::Config, filters: Filters) -> Self { Self { config, filters } }
 
+    // TODO: plumb a caller-provided CancellationToken into `connect` once
+    // `SourceTrait::connect` exposes a cancellation hook. Upstream
+    // `firehose()` accepts an `Option<broadcast::Receiver<()>>` for
+    // cooperative shutdown but we currently pass `None`.
     async fn connect(
         &self,
         tx: Sender<Result<SubscribeUpdate, yellowstone_grpc_proto::tonic::Status>>,
@@ -486,11 +503,14 @@ impl SourceTrait for JetstreamSource {
             expected.validate_matches(&ProcessEnvConfig::from_process())?;
         }
 
-        let cancellation_token = CancellationToken::new();
-        let token = cancellation_token.clone();
+        if config.buffer_window_bytes.is_some() && !config.sequential {
+            tracing::warn!(
+                "`buffer_window_bytes` is set but `sequential` is false; the value will be ignored by jetstreamer-firehose"
+            );
+        }
 
         tokio::spawn(async move {
-            let exit_status = match Self::stream_loop(config, filters, tx.clone(), token).await {
+            let exit_status = match Self::stream_loop(config, filters, tx.clone()).await {
                 Ok(()) => SourceExitStatus::Completed,
                 Err(e) => {
                     error!(error = %e, "Jetstream streaming failed");
@@ -514,7 +534,6 @@ impl JetstreamSource {
         config: JetstreamSourceConfig,
         filters: Filters,
         tx: Sender<Result<SubscribeUpdate, yellowstone_grpc_proto::tonic::Status>>,
-        _cancellation_token: CancellationToken,
     ) -> Result<(), Error> {
         let (start_slot, end_slot) = config.range.to_slot_range().map_err(|e| {
             Error::SlotRangeResolution(format!(
@@ -551,6 +570,8 @@ impl JetstreamSource {
 
         let result = firehose(
             config.threads as u64,
+            config.sequential,
+            config.buffer_window_bytes,
             start_slot..end_slot,
             on_block,
             on_tx,
@@ -564,7 +585,7 @@ impl JetstreamSource {
                     >,
                 >,
             >,
-            None,
+            None::<broadcast::Receiver<()>>,
         )
         .await;
 
@@ -700,6 +721,8 @@ mod tests {
             network: "mainnet".to_string(),
             compact_index_base_url: "https://files.old-faithful.net".to_string(),
             network_capacity_mb: 1000,
+            sequential: false,
+            buffer_window_bytes: None,
             possible_leader_skipped_tx: None,
         };
 
@@ -709,6 +732,60 @@ mod tests {
         assert_eq!(source.config.archive_url, "https://api.old-faithful.net");
         assert_eq!(source.config.threads, 4);
         assert_eq!(source.config.network, "mainnet");
+        assert!(!source.config.sequential);
+        assert!(source.config.buffer_window_bytes.is_none());
+    }
+
+    #[test]
+    fn test_jetstream_source_config_toml_roundtrip() {
+        let toml_str = r#"
+archive-url = "https://api.old-faithful.net"
+threads = 4
+network = "mainnet"
+compact-index-base-url = "https://files.old-faithful.net"
+network-capacity-mb = 1000
+sequential = true
+buffer-window-bytes = 1073741824
+
+[range]
+slot-start = 1000
+slot-end = 2000
+"#;
+
+        let config: JetstreamSourceConfig =
+            toml::from_str(toml_str).expect("valid TOML for JetstreamSourceConfig");
+
+        assert!(config.sequential);
+        assert_eq!(config.buffer_window_bytes, Some(1_073_741_824));
+        assert_eq!(config.archive_url, "https://api.old-faithful.net");
+        assert_eq!(config.threads, 4);
+    }
+
+    #[test]
+    fn test_jetstream_source_config_toml_defaults_when_omitted() {
+        let toml_str = r#"
+archive-url = "https://api.old-faithful.net"
+threads = 4
+network = "mainnet"
+compact-index-base-url = "https://files.old-faithful.net"
+network-capacity-mb = 1000
+
+[range]
+slot-start = 1000
+slot-end = 2000
+"#;
+
+        let config: JetstreamSourceConfig = toml::from_str(toml_str)
+            .expect("TOML omitting `sequential` and `buffer-window-bytes` must deserialize");
+
+        assert!(
+            !config.sequential,
+            "`sequential` must default to false when absent from TOML"
+        );
+        assert!(
+            config.buffer_window_bytes.is_none(),
+            "`buffer_window_bytes` must default to None when absent from TOML"
+        );
     }
 
     #[tokio::test]

--- a/examples/jetstreamer/src/config.toml
+++ b/examples/jetstreamer/src/config.toml
@@ -2,11 +2,18 @@
 archive-url = "https://api.old-faithful.net"
 epoch = 885
 threads = 4
-reorder-buffer-size = 1000
-slot-timeout-secs = 30
 network = "mainnet"
 compact-index-base-url = "https://files.old-faithful.net"
 network-capacity-mb = 1000
+
+# Optional: enable upstream's sequential mode (single firehose worker thread
+# with parallel ripget downloads, ≥150k TPS). When disabled, `threads` controls
+# parallel firehose workers; when enabled, it controls ripget concurrency.
+# sequential = false
+
+# Optional: ripget hot/cold window size in bytes; only takes effect when
+# `sequential = true`. Defaults to min(4 GiB, 15% of available RAM).
+# buffer-window-bytes = 1073741824
 
 [filters]
 # Add any filters needed for parsing specific programs or accounts

--- a/examples/jetstreamer/src/main.rs
+++ b/examples/jetstreamer/src/main.rs
@@ -180,6 +180,8 @@ fn main() -> Result<()> {
         network: "mainnet".to_string(),
         compact_index_base_url: "https://files.old-faithful.net".to_string(),
         network_capacity_mb: 100000,
+        sequential: false,
+        buffer_window_bytes: None,
         possible_leader_skipped_tx: None,
     };
 


### PR DESCRIPTION
Adapts the firehose() call site to the new signature and exposes `sequential` and `buffer_window_bytes` on JetstreamSourceConfig. Adds a TOML round-trip test and a CHANGELOG entry.