### PR TITLE
fix: handle source startup errors

### DIFF
--- a/crates/solana-rpc-source/src/lib.rs
+++ b/crates/solana-rpc-source/src/lib.rs
@@ -162,6 +162,9 @@ impl SourceTrait for SolanaAccountsRpcSource {
 
         let mut exit_status = SourceExitStatus::Completed;
 
+        // One task runs per (filter, owner) pair and the runtime treats a source
+        // `Error` as fatal, so the first failure wins: keeping later errors adds
+        // nothing, and updates already sent by sibling tasks stay in the buffer.
         while let Some(task_result) = tasks_set.join_next().await {
             match task_result {
                 Ok(Ok(())) => {},
@@ -226,6 +229,54 @@ mod tests {
                 .expect("connect should report task failure through source status");
 
             let status = status_rx.await.expect("source status should be sent");
+            let yellowstone_vixen::sources::SourceExitStatus::Error(msg) = status else {
+                panic!("expected source error, got {status:?}");
+            };
+            assert!(msg.contains("Failed to get slot for source: solana-rpc"));
+            assert!(rx.try_recv().is_err());
+        });
+    }
+
+    #[test]
+    fn connect_with_multiple_filters_reports_single_error_status() {
+        let runtime = tokio::runtime::Runtime::new().expect("runtime should build");
+
+        runtime.block_on(async {
+            let filters = Filters::new(HashMap::from([
+                (
+                    "filter-a".to_string(),
+                    Prefilter::builder()
+                        .account_owners([[1_u8; 32]])
+                        .build()
+                        .expect("account owner filter should build"),
+                ),
+                (
+                    "filter-b".to_string(),
+                    Prefilter::builder()
+                        .account_owners([[2_u8; 32]])
+                        .build()
+                        .expect("account owner filter should build"),
+                ),
+            ]));
+            let source = SolanaAccountsRpcSource::new(
+                SolanaAccountsRpcConfig {
+                    endpoint: "http://127.0.0.1:9".to_string(),
+                    timeout: 1,
+                    commitment_level: Some(CommitmentLevel::Confirmed),
+                },
+                filters,
+            );
+            let (tx, mut rx) = mpsc::channel(1);
+            let (status_tx, status_rx) = oneshot::channel();
+
+            source
+                .connect(tx, status_tx)
+                .await
+                .expect("connect should report task failures through source status");
+
+            let status = status_rx
+                .await
+                .expect("source status should be sent exactly once");
             let yellowstone_vixen::sources::SourceExitStatus::Error(msg) = status else {
                 panic!("expected source error, got {status:?}");
             };

--- a/crates/solana-rpc-source/src/lib.rs
+++ b/crates/solana-rpc-source/src/lib.rs
@@ -94,16 +94,12 @@ impl SourceTrait for SolanaAccountsRpcSource {
                     );
 
                     tasks_set.spawn(async move {
-                        let slot = client.get_slot().await;
-
-                        if let Err(e) = &slot {
-                            tracing::error!(
-                                "Failed to get slot: {} for source: solana-rpc, filter: {}",
-                                e,
-                                filter_id
-                            );
-                        }
-                        let slot = slot.unwrap();
+                        let slot = client.get_slot().await.map_err(|e| {
+                            format!(
+                                "Failed to get slot for source: solana-rpc, filter: {filter_id}: \
+                                 {e}"
+                            )
+                        })?;
 
                         let accounts = client
                             .get_program_accounts_with_config(
@@ -121,18 +117,14 @@ impl SourceTrait for SolanaAccountsRpcSource {
                                 },
                             )
                             .await
-                            .map_err(|e| VixenError::Io(std::io::Error::other(e.to_string())));
+                            .map_err(|e| {
+                                format!(
+                                    "Failed to get program accounts for source: solana-rpc, \
+                                     filter: {filter_id}: {e}"
+                                )
+                            })?;
 
-                        if let Err(e) = &accounts {
-                            tracing::error!(
-                                "Failed to get program accounts: {} for source: solana-rpc, \
-                                 filter: {}",
-                                e,
-                                filter_id
-                            );
-                        }
-
-                        for (acc_pubkey, account) in accounts.unwrap() {
+                        for (acc_pubkey, account) in accounts {
                             let update = SubscribeUpdate {
                                 filters: vec![filter_id.clone()],
                                 created_at: None,
@@ -155,21 +147,90 @@ impl SourceTrait for SolanaAccountsRpcSource {
                             let res = tx.send(Ok(update)).await;
 
                             if res.is_err() {
-                                tracing::error!(
+                                return Err(format!(
                                     "Failed to send update to buffer for source: solana-rpc, \
-                                     filter: {}",
-                                    filter_id
-                                );
+                                     filter: {filter_id}"
+                                ));
                             }
                         }
+
+                        Ok::<(), String>(())
                     });
                 }
             }
         }
 
-        tasks_set.join_all().await;
+        let mut exit_status = SourceExitStatus::Completed;
 
-        let _ = status_tx.send(SourceExitStatus::Completed);
+        while let Some(task_result) = tasks_set.join_next().await {
+            match task_result {
+                Ok(Ok(())) => {},
+                Ok(Err(msg)) => {
+                    tracing::error!(%msg, "Solana RPC source task failed");
+
+                    if matches!(exit_status, SourceExitStatus::Completed) {
+                        exit_status = SourceExitStatus::Error(msg);
+                    }
+                },
+                Err(e) => {
+                    tracing::error!(err = %e, "Solana RPC source task panicked or was cancelled");
+
+                    if matches!(exit_status, SourceExitStatus::Completed) {
+                        exit_status = SourceExitStatus::Error(e.to_string());
+                    }
+                },
+            }
+        }
+
+        let _ = status_tx.send(exit_status);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use tokio::sync::{mpsc, oneshot};
+    use yellowstone_vixen::{sources::SourceTrait, CommitmentLevel};
+    use yellowstone_vixen_core::{Filters, Prefilter};
+
+    use super::{SolanaAccountsRpcConfig, SolanaAccountsRpcSource};
+
+    #[test]
+    fn connect_reports_rpc_errors_instead_of_panicking() {
+        let runtime = tokio::runtime::Runtime::new().expect("runtime should build");
+
+        runtime.block_on(async {
+            let filters = Filters::new(HashMap::from([(
+                "test-filter".to_string(),
+                Prefilter::builder()
+                    .account_owners([[1_u8; 32]])
+                    .build()
+                    .expect("account owner filter should build"),
+            )]));
+            let source = SolanaAccountsRpcSource::new(
+                SolanaAccountsRpcConfig {
+                    endpoint: "http://127.0.0.1:9".to_string(),
+                    timeout: 1,
+                    commitment_level: Some(CommitmentLevel::Confirmed),
+                },
+                filters,
+            );
+            let (tx, mut rx) = mpsc::channel(1);
+            let (status_tx, status_rx) = oneshot::channel();
+
+            source
+                .connect(tx, status_tx)
+                .await
+                .expect("connect should report task failure through source status");
+
+            let status = status_rx.await.expect("source status should be sent");
+            let yellowstone_vixen::sources::SourceExitStatus::Error(msg) = status else {
+                panic!("expected source error, got {status:?}");
+            };
+            assert!(msg.contains("Failed to get slot for source: solana-rpc"));
+            assert!(rx.try_recv().is_err());
+        });
     }
 }

--- a/crates/yellowstone-fumarole-source/src/lib.rs
+++ b/crates/yellowstone-fumarole-source/src/lib.rs
@@ -94,9 +94,15 @@ impl SourceTrait for YellowstoneFumaroleSource {
             ..Default::default()
         };
 
-        let mut fumarole_client = FumaroleClient::connect(self.config.clone().into())
-            .await
-            .expect("failing to connect to fumarole");
+        let mut fumarole_client = match FumaroleClient::connect(self.config.clone().into()).await {
+            Ok(client) => client,
+            Err(e) => {
+                let msg = format!("Failed to connect to fumarole: {e}");
+                tracing::error!(%msg, "Fumarole source connection failed");
+                let _ = status_tx.send(SourceExitStatus::Error(msg));
+                return Ok(());
+            },
+        };
 
         let mut subscribe_request = SubscribeRequest::from(filters);
 
@@ -104,14 +110,22 @@ impl SourceTrait for YellowstoneFumaroleSource {
             subscribe_request.commitment = Some(commitment_level as i32);
         }
 
-        let dragonsmouth_session = fumarole_client
+        let dragonsmouth_session = match fumarole_client
             .dragonsmouth_subscribe_with_config(
                 subscriber_name,
                 subscribe_request,
                 fumarole_subscribe_config,
             )
             .await
-            .expect("failing to subscribe to fumarole");
+        {
+            Ok(session) => session,
+            Err(e) => {
+                let msg = format!("Failed to subscribe to fumarole: {e}");
+                tracing::error!(%msg, "Fumarole source subscription failed");
+                let _ = status_tx.send(SourceExitStatus::Error(msg));
+                return Ok(());
+            },
+        };
 
         let DragonsmouthAdapterSession {
             sink: _,
@@ -142,5 +156,46 @@ impl SourceTrait for YellowstoneFumaroleSource {
 
         let _ = status_tx.send(exit_status);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use tokio::sync::{mpsc, oneshot};
+    use yellowstone_vixen::sources::SourceTrait;
+    use yellowstone_vixen_core::Filters;
+
+    use super::{FumaroleConfig, YellowstoneFumaroleSource};
+
+    #[test]
+    fn connect_reports_connection_errors_instead_of_panicking() {
+        let runtime = tokio::runtime::Runtime::new().expect("runtime should build");
+
+        runtime.block_on(async {
+            let source = YellowstoneFumaroleSource::new(
+                FumaroleConfig {
+                    endpoint: "http://127.0.0.1:9".to_string(),
+                    subscriber_name: "test-subscriber".to_string(),
+                    ..FumaroleConfig::default()
+                },
+                Filters::new(HashMap::new()),
+            );
+            let (tx, mut rx) = mpsc::channel(1);
+            let (status_tx, status_rx) = oneshot::channel();
+
+            source
+                .connect(tx, status_tx)
+                .await
+                .expect("connect should report connection failure through source status");
+
+            let status = status_rx.await.expect("source status should be sent");
+            let yellowstone_vixen::sources::SourceExitStatus::Error(msg) = status else {
+                panic!("expected source error, got {status:?}");
+            };
+            assert!(msg.contains("Failed to connect to fumarole"));
+            assert!(rx.try_recv().is_err());
+        });
     }
 }

--- a/crates/yellowstone-fumarole-source/src/lib.rs
+++ b/crates/yellowstone-fumarole-source/src/lib.rs
@@ -119,10 +119,16 @@ impl SourceTrait for YellowstoneFumaroleSource {
             .await
         {
             Ok(session) => session,
-            Err(e) => {
-                let msg = format!("Failed to subscribe to fumarole: {e}");
-                tracing::error!(%msg, "Fumarole source subscription failed");
-                let _ = status_tx.send(SourceExitStatus::Error(msg));
+            Err(status) => {
+                tracing::error!(
+                    code = ?status.code(),
+                    message = status.message(),
+                    "Fumarole source subscription failed"
+                );
+                let _ = status_tx.send(SourceExitStatus::StreamError {
+                    code: status.code(),
+                    message: status.message().to_owned(),
+                });
                 return Ok(());
             },
         };


### PR DESCRIPTION
This fixes panic paths in the Solana RPC and Fumarole sources.

RPC failures and Fumarole connect failures now return a source error status instead of panicking or closing the status channel unexpectedly. Fumarole subscribe failures surface as `StreamError`, preserving the gRPC status code (connect failures stay `Error(String)` because the client's `ConnectError` carries no gRPC code).

Added regression coverage for both failure paths, plus a multi-filter test asserting a single error status is delivered when any filter's RPC call fails.

## Behavioral changes

- In the RPC source, a failed `tx.send` (buffer receiver dropped) now ends that task immediately instead of logging and continuing with the remaining accounts.
- Only the first task error is retained: one filter's failure aborts the whole pipeline (the runtime treats a source `Error` as fatal), even if other filters loaded successfully. Updates already sent by sibling tasks remain in the buffer.
