### PR TITLE
feat: update yellowstone-grpc-client to v13.1 with auto-reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and adheres to [Semantic Versioning](https://semver.org/).
 
 - `yellowstone-vixen-jetstream-source`: bumped `jetstreamer-firehose` and `jetstreamer-utils` from `0.2` to `0.5` to track upstream Anza releases.
 - **Breaking** for downstream struct-literal construction: `JetstreamSourceConfig` gained two new fields, `sequential: bool` (default `false`) and `buffer_window_bytes: Option<u64>` (default `None`), to expose the upstream `sequential` / ripget buffer-window controls. Both are `#[serde(default)]` and have clap defaults, so deserialized and CLI-built configs are unaffected; only direct struct-literal initialization needs updating.
+- Bumped `yellowstone-grpc-client` from `12` to `13.1` and `yellowstone-grpc-proto` from `12` to `12.4`, picking up the client's built-in auto-reconnect support introduced in v13.1.
+- Auto-reconnect on the Yellowstone gRPC source is now **on by default**. It is configured via three new `YellowstoneGrpcConfig` fields: `auto-reconnect` (bool, default `true`), `reconnect-max-retries`, and `reconnect-slot-retention`. When enabled the source uses a sturdy default backoff (10 retries, 500 ms base, 2.0× multiplier — covers outages up to ~4 minutes) instead of the client library's weaker default. Set `auto-reconnect = false` to opt out. Existing config files keep deserializing (`#[serde(default)]`), but downstream struct-literal construction of `YellowstoneGrpcConfig` must initialize the new fields. Requires the server to have `replay_stored_slots` configured for gap-free recovery.
+
+### Added
+
+- `SubscribeRequest` filter structs gained `cuckoo_accounts_filter` (`SubscribeRequestFilterAccounts`), `token_accounts` (`SubscribeRequestFilterTransactions`), and `cuckoo_account_include` (`SubscribeRequestFilterBlocks`) from `yellowstone-grpc-proto` 12.5. All are defaulted to `None`, preserving prior behavior.
+- `Reward` gained `commission_bps` (string) from `yellowstone-grpc-proto` 12.5; defaulted to an empty string on the jetstream source's reward conversion paths.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14060,7 +14060,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "clap 4.5.53",
@@ -14081,7 +14081,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-block-coordinator"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bs58",
@@ -14105,7 +14105,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-block-meta-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -14118,7 +14118,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-bpf-loader-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bincode",
  "prost 0.14.1",
@@ -14134,7 +14134,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-core"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "borsh 1.6.0",
  "bs58",
@@ -14260,7 +14260,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-jetstream-source"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bincode",
@@ -14292,7 +14292,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-kafka-sink"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "futures 0.3.31",
  "mockito",
@@ -14311,7 +14311,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-mock"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "futures 0.3.31",
  "regex",
@@ -14327,7 +14327,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -14342,7 +14342,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-proc-macro"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -14359,7 +14359,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-proto"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "prost 0.14.1",
  "prost-types 0.14.1",
@@ -14372,7 +14372,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-slot-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "tokio",
  "yellowstone-vixen-core",
@@ -14381,7 +14381,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-solana-rpc-source"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "clap 4.5.53",
@@ -14399,7 +14399,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-solana-snapshot-source"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "agave-snapshots",
  "async-trait",
@@ -14426,7 +14426,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-spl-token-extensions-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "borsh 1.6.0",
  "bs58",
@@ -14452,7 +14452,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-spl-token-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bs58",
  "bytemuck",
@@ -14475,7 +14475,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-stake-pool-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "borsh 1.6.0",
  "bs58",
@@ -14494,7 +14494,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-stream"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "clap 4.5.53",
@@ -14518,7 +14518,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-yellowstone-fumarole-source"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bytesize 2.3.1",
@@ -14537,7 +14537,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-yellowstone-grpc-source"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "clap 4.5.53",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,7 +366,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -377,14 +377,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "aquamarine"
@@ -1605,7 +1605,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2561,7 +2561,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4650,7 +4650,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5783,9 +5783,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -6366,7 +6366,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6446,7 +6446,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12279,7 +12279,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -13434,7 +13434,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
  "solana-signature 3.1.0",
  "solana-transaction",
  "solana-transaction-status",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -181,7 +181,7 @@ dependencies = [
  "symlink",
  "tar",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zstd",
 ]
 
@@ -225,7 +225,7 @@ dependencies = [
  "solana-sysvar 3.1.1",
  "solana-sysvar-id 3.1.0",
  "solana-transaction-context",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -397,7 +397,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -523,7 +523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -549,7 +549,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -624,7 +624,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -763,7 +763,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -774,7 +774,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1015,7 +1015,7 @@ dependencies = [
  "regex",
  "rustc-hash 2.1.1",
  "shlex",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1166,7 +1166,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1281,7 +1281,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1416,7 +1416,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1522,7 +1522,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1549,8 +1549,8 @@ dependencies = [
  "cargo_toml",
  "proc-macro2",
  "serde_json",
- "syn 2.0.111",
- "thiserror 2.0.17",
+ "syn 2.0.118",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1577,7 +1577,7 @@ dependencies = [
  "derive_more 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1590,7 +1590,7 @@ dependencies = [
  "derive_more 1.0.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1980,7 +1980,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1989,8 +1989,18 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -2004,7 +2014,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.111",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2013,9 +2036,20 @@ version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "darling_core",
+ "darling_core 0.21.3",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2056,7 +2090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.111",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2120,7 +2154,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2149,7 +2183,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2162,7 +2196,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.111",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -2255,7 +2289,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2275,7 +2309,7 @@ checksum = "c32e3e8ab1b6ee2e06418f40f94f315d82b35157eb1d2322a6e20a4b15106b84"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2298,7 +2332,7 @@ checksum = "a6cbae11b3de8fce2a456e8ea3dada226b35fe791f0dc1d360c0941f0bb681f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2408,7 +2442,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2468,7 +2502,7 @@ checksum = "685adfa4d6f3d765a26bc5dbc936577de9abf756c1feeb3089b01dd395034842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2488,7 +2522,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2824,7 +2858,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3811,7 +3845,7 @@ dependencies = [
  "solana-storage-proto",
  "solana-transaction",
  "solana-transaction-status",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "url 2.5.7",
  "wincode 0.2.5",
@@ -3854,7 +3888,7 @@ checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4256,7 +4290,7 @@ dependencies = [
  "quote",
  "regex-syntax",
  "rustc_version",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4404,7 +4438,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4510,7 +4544,7 @@ checksum = "8462d3cc74eaf4194f6c0bd7b18c6f3fa6293297f4bdb60fe4c4b022ea366e12"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4678,7 +4712,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4751,7 +4785,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4825,7 +4859,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4880,7 +4914,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
@@ -4924,7 +4958,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost 0.13.5",
  "reqwest 0.12.24",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.12.3",
  "tracing",
@@ -4968,7 +5002,7 @@ dependencies = [
  "percent-encoding 2.3.2",
  "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5042,6 +5076,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pbkdf2"
@@ -5122,7 +5162,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5162,7 +5202,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5297,7 +5337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5367,9 +5407,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
@@ -5388,7 +5428,7 @@ dependencies = [
  "parking_lot 0.12.5",
  "protobuf",
  "reqwest 0.12.24",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5459,7 +5499,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "regex",
- "syn 2.0.111",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -5481,7 +5521,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.111",
+ "syn 2.0.118",
  "tempfile",
 ]
 
@@ -5508,7 +5548,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5521,7 +5561,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5663,7 +5703,7 @@ dependencies = [
  "logos",
  "miette",
  "prost-types 0.14.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5703,7 +5743,7 @@ checksum = "9e2e25ee72f5b24d773cae88422baddefff7714f97aab68d96fe2b6fc4a28fb2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5735,7 +5775,7 @@ dependencies = [
  "rustc-hash 2.1.1",
  "rustls 0.23.35",
  "socket2 0.6.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -5758,7 +5798,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5780,9 +5820,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -6040,7 +6080,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6628,7 +6668,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6690,10 +6730,10 @@ version = "3.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6731,7 +6771,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6781,6 +6821,12 @@ dependencies = [
  "cpufeatures",
  "digest 0.10.7",
 ]
+
+[[package]]
+name = "sha2-const-stable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f179d4e11094a893b82fff208f74d448a7512f99f5a0acbd5c679b705f83ed9"
 
 [[package]]
 name = "sha3"
@@ -7020,7 +7066,7 @@ dependencies = [
  "spl-token-group-interface 0.7.1",
  "spl-token-interface",
  "spl-token-metadata-interface 0.8.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zstd",
 ]
 
@@ -7060,7 +7106,7 @@ checksum = "fc3397241392f5756925029acaa8515dc70fcbe3d8059d4885d7d6533baf64fd"
 dependencies = [
  "bincode",
  "serde_core",
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
  "solana-program-error 3.0.0",
  "solana-program-memory 3.1.0",
 ]
@@ -7121,7 +7167,7 @@ dependencies = [
  "spl-generic-token",
  "static_assertions",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7130,14 +7176,14 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2ecac8e1b7f74c2baa9e774c42817e3e75b20787134b76cc4d45e8a604488f5"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
 name = "solana-address"
-version = "2.0.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e37320fd2945c5d654b2c6210624a52d66c3f1f73b653ed211ab91a703b35bdd"
+checksum = "39c93e262f671bf402e1040e4a7e40b05d81da5956c7681948c975a0997517bb"
 dependencies = [
  "borsh 1.6.0",
  "bytemuck",
@@ -7145,14 +7191,16 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "five8 1.0.0",
  "five8_const 1.0.0",
- "rand 0.8.5",
+ "rand 0.9.2",
  "serde",
  "serde_derive",
+ "sha2-const-stable",
  "solana-atomic-u64 3.0.0",
- "solana-define-syscall 4.0.1",
+ "solana-define-syscall 5.1.0",
  "solana-program-error 3.0.0",
  "solana-sanitize 3.0.1",
  "solana-sha256-hasher 3.1.0",
+ "wincode 0.5.5",
 ]
 
 [[package]]
@@ -7310,7 +7358,7 @@ dependencies = [
  "solana-signature 3.1.0",
  "solana-signer 3.0.0",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7325,7 +7373,7 @@ dependencies = [
  "ark-serialize 0.4.2",
  "bytemuck",
  "solana-define-syscall 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7457,7 +7505,7 @@ dependencies = [
  "solana-seed-phrase 3.0.0",
  "solana-signature 3.1.0",
  "solana-signer 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tiny-bip39",
  "uriparse",
  "url 2.5.7",
@@ -7562,7 +7610,7 @@ dependencies = [
  "solana-transaction-error 3.0.0",
  "solana-transaction-status-client-types",
  "solana-udp-client",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.17",
 ]
@@ -7663,7 +7711,7 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-svm-transaction",
  "solana-transaction-error 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7722,7 +7770,7 @@ dependencies = [
  "solana-metrics",
  "solana-time-utils",
  "solana-transaction-error 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -7778,7 +7826,7 @@ dependencies = [
  "solana-define-syscall 4.0.1",
  "solana-instruction 3.0.0",
  "solana-program-error 3.0.0",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
  "solana-stable-layout 3.0.0",
 ]
 
@@ -7793,7 +7841,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-define-syscall 2.3.0",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7807,7 +7855,7 @@ dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-define-syscall 3.0.0",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7836,6 +7884,12 @@ name = "solana-define-syscall"
 version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57e5b1c0bc1d4a4d10c88a4100499d954c09d3fecfae4912c1a074dff68b1738"
+
+[[package]]
+name = "solana-define-syscall"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21e14a4f604117f379840956a8fc8695e4c84f5b0ebed192f31f60d9b85d581d"
 
 [[package]]
 name = "solana-derivation-path"
@@ -7961,7 +8015,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ee8beac9bff4db9225e57d532d169b0be5e447f1e6601a2f50f27a01bf5518f"
 dependencies = [
  "siphasher 0.3.11",
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
  "solana-hash 4.0.1",
 ]
 
@@ -8019,7 +8073,7 @@ dependencies = [
  "solana-pubkey 2.4.0",
  "solana-sdk-ids 2.2.1",
  "solana-system-interface 1.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8040,7 +8094,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-sdk-ids 3.1.0",
  "solana-system-interface 2.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8072,7 +8126,7 @@ dependencies = [
  "solana-transaction",
  "solana-version",
  "spl-memo-interface",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -8210,7 +8264,7 @@ dependencies = [
  "solana-genesis-config",
  "solana-hash 3.1.0",
  "solana-rpc-client",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8241,7 +8295,7 @@ dependencies = [
  "solana-signature 3.1.0",
  "solana-transaction",
  "solana-transaction-status",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -8309,7 +8363,7 @@ dependencies = [
  "solana-vote",
  "solana-vote-program",
  "static_assertions",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -8628,7 +8682,7 @@ dependencies = [
  "strum_macros 0.24.3",
  "tar",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "trees",
@@ -8833,7 +8887,7 @@ dependencies = [
  "solana-cluster-type",
  "solana-sha256-hasher 3.1.0",
  "solana-time-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9020,7 +9074,7 @@ dependencies = [
  "solana-runtime",
  "solana-time-utils",
  "solana-transaction",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9044,7 +9098,7 @@ dependencies = [
  "light-poseidon 0.2.0",
  "light-poseidon 0.4.0",
  "solana-define-syscall 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9143,7 +9197,7 @@ dependencies = [
  "solana-sysvar 2.3.0",
  "solana-sysvar-id 2.2.1",
  "solana-vote-interface 2.2.6",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
 ]
 
@@ -9215,7 +9269,7 @@ dependencies = [
  "solana-account-info 3.1.0",
  "solana-define-syscall 4.0.1",
  "solana-program-error 3.0.0",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
 ]
 
 [[package]]
@@ -9335,7 +9389,7 @@ dependencies = [
  "solana-sysvar 3.1.1",
  "solana-sysvar-id 3.1.0",
  "solana-transaction-context",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9376,11 +9430,11 @@ dependencies = [
 
 [[package]]
 name = "solana-pubkey"
-version = "4.0.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6f7104d456b58e1418c21a8581e89810278d1190f70f27ece7fc0b2c9282a57"
+checksum = "7db719574990de7e8b0f55a8593ac92a5ccb42c8ce67b3e4bf05b139d5d9ee71"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
@@ -9401,7 +9455,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rpc-client-types",
  "solana-signature 3.1.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -9435,7 +9489,7 @@ dependencies = [
  "solana-streamer",
  "solana-tls-utils",
  "solana-transaction-error 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -9477,7 +9531,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-signature 3.1.0",
  "solana-signer 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "uriparse",
 ]
 
@@ -9598,7 +9652,7 @@ dependencies = [
  "spl-token-2022-interface",
  "spl-token-interface",
  "stream-cancel",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.17",
 ]
@@ -9661,7 +9715,7 @@ dependencies = [
  "solana-signer 3.0.0",
  "solana-transaction-error 3.0.0",
  "solana-transaction-status-client-types",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9678,7 +9732,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "solana-rpc-client",
  "solana-sdk-ids 3.1.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9705,7 +9759,7 @@ dependencies = [
  "solana-transaction-status-client-types",
  "solana-version",
  "spl-generic-token",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9842,7 +9896,7 @@ dependencies = [
  "strum_macros 0.24.3",
  "symlink",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9864,7 +9918,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9892,7 +9946,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rustc-demangle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "winapi 0.3.9",
 ]
 
@@ -9931,7 +9985,7 @@ dependencies = [
  "solana-time-utils",
  "solana-transaction",
  "solana-transaction-error 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -9949,7 +10003,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "def234c1956ff616d46c9dd953f251fa7096ddbaa6d52b165218de97882b7280"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
 ]
 
 [[package]]
@@ -9961,7 +10015,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9973,7 +10027,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9998,7 +10052,7 @@ checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
 dependencies = [
  "libsecp256k1",
  "solana-define-syscall 2.3.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10009,7 +10063,7 @@ checksum = "9de18cfdab99eeb940fbedd8c981fa130c0d76252da75d05446f22fae8b51932"
 dependencies = [
  "k256",
  "solana-define-syscall 4.0.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10395,7 +10449,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-error 3.0.0",
  "solana-transaction-status",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.9.2",
  "zstd",
@@ -10468,7 +10522,7 @@ dependencies = [
  "solana-tls-utils",
  "solana-transaction-error 3.0.0",
  "solana-transaction-metrics-tracker",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.17",
  "x509-parser",
@@ -10514,7 +10568,7 @@ dependencies = [
  "solana-transaction-context",
  "solana-transaction-error 3.0.0",
  "spl-generic-token",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10718,7 +10772,7 @@ dependencies = [
  "solana-program-entrypoint 3.1.1",
  "solana-program-error 3.0.0",
  "solana-program-memory 3.1.0",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
  "solana-rent 3.0.0",
  "solana-sdk-ids 3.1.0",
  "solana-sdk-macro 3.0.0",
@@ -10743,7 +10797,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
  "solana-sdk-ids 3.1.0",
 ]
 
@@ -10796,7 +10850,7 @@ dependencies = [
  "solana-signer 3.0.0",
  "solana-transaction",
  "solana-transaction-error 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -10822,7 +10876,7 @@ dependencies = [
  "solana-time-utils",
  "solana-tls-utils",
  "solana-tpu-client",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-util 0.7.17",
 ]
@@ -10836,7 +10890,7 @@ dependencies = [
  "bincode",
  "serde",
  "serde_derive",
- "solana-address 2.0.0",
+ "solana-address 2.6.1",
  "solana-hash 4.0.1",
  "solana-instruction 3.0.0",
  "solana-instruction-error",
@@ -10944,7 +10998,7 @@ dependencies = [
  "spl-token-group-interface 0.7.1",
  "spl-token-interface",
  "spl-token-metadata-interface 0.8.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10968,7 +11022,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-transaction-error 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -10983,7 +11037,7 @@ dependencies = [
  "solana-net-utils",
  "solana-streamer",
  "solana-transaction-error 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -11045,7 +11099,7 @@ dependencies = [
  "solana-svm-transaction",
  "solana-transaction",
  "solana-vote-interface 4.0.4",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11127,7 +11181,7 @@ dependencies = [
  "solana-transaction",
  "solana-transaction-context",
  "solana-vote-interface 4.0.4",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11178,7 +11232,7 @@ dependencies = [
  "solana-signature 2.3.0",
  "solana-signer 2.2.1",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -11215,7 +11269,7 @@ dependencies = [
  "solana-signature 3.1.0",
  "solana-signer 3.0.0",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "zeroize",
 ]
@@ -11267,7 +11321,7 @@ dependencies = [
  "solana-signature 3.1.0",
  "solana-signer 3.0.0",
  "subtle",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "zeroize",
 ]
 
@@ -11342,7 +11396,7 @@ checksum = "d9e8418ea6269dcfb01c712f0444d2c75542c04448b480e87de59d2865edc750"
 dependencies = [
  "quote",
  "spl-discriminator-syn",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11354,7 +11408,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "syn 2.0.111",
+ "syn 2.0.118",
  "thiserror 1.0.69",
 ]
 
@@ -11448,7 +11502,7 @@ dependencies = [
  "solana-program-option 2.2.1",
  "solana-pubkey 2.4.0",
  "solana-zk-sdk 2.3.13",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11467,7 +11521,7 @@ dependencies = [
  "solana-program-option 3.0.0",
  "solana-pubkey 3.0.0",
  "solana-zk-sdk 4.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11482,7 +11536,7 @@ dependencies = [
  "solana-msg 2.2.1",
  "solana-program-error 2.2.2",
  "spl-program-error-derive 0.5.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11497,7 +11551,7 @@ dependencies = [
  "solana-msg 3.0.0",
  "solana-program-error 3.0.0",
  "spl-program-error-derive 0.6.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11509,7 +11563,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11521,7 +11575,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2 0.10.9",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -11545,7 +11599,7 @@ dependencies = [
  "solana-system-interface 1.0.0",
  "spl-pod 0.5.1",
  "spl-token-2022 9.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11567,7 +11621,7 @@ dependencies = [
  "spl-pod 0.5.1",
  "spl-program-error 0.7.0",
  "spl-type-length-value 0.8.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11588,7 +11642,7 @@ dependencies = [
  "spl-pod 0.7.1",
  "spl-program-error 0.8.0",
  "spl-type-length-value 0.9.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11616,7 +11670,7 @@ dependencies = [
  "solana-rent 2.2.1",
  "solana-sdk-ids 2.2.1",
  "solana-sysvar 2.3.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11644,7 +11698,7 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-sysvar 3.1.1",
  "spl-token-interface",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11688,7 +11742,7 @@ dependencies = [
  "spl-token-metadata-interface 0.7.0",
  "spl-transfer-hook-interface 0.10.0",
  "spl-type-length-value 0.8.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11729,7 +11783,7 @@ dependencies = [
  "spl-token-group-interface 0.7.1",
  "spl-token-metadata-interface 0.8.0",
  "spl-transfer-hook-interface 2.1.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11757,7 +11811,7 @@ dependencies = [
  "spl-token-group-interface 0.7.1",
  "spl-token-metadata-interface 0.8.0",
  "spl-type-length-value 0.9.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11801,7 +11855,7 @@ dependencies = [
  "solana-sdk-ids 2.2.1",
  "solana-zk-sdk 2.3.13",
  "spl-pod 0.5.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11821,7 +11875,7 @@ dependencies = [
  "solana-sdk-ids 3.1.0",
  "solana-zk-sdk 4.0.0",
  "spl-pod 0.7.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11832,7 +11886,7 @@ checksum = "fa27b9174bea869a7ebf31e0be6890bce90b1a4288bc2bbf24bd413f80ae3fde"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-sdk 2.3.13",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11843,7 +11897,7 @@ checksum = "a0cd59fce3dc00f563c6fa364d67c3f200d278eae681f4dc250240afcfe044b1"
 dependencies = [
  "curve25519-dalek 4.1.3",
  "solana-zk-sdk 4.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11862,7 +11916,7 @@ dependencies = [
  "solana-pubkey 2.4.0",
  "spl-discriminator 0.4.1",
  "spl-pod 0.5.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11880,7 +11934,7 @@ dependencies = [
  "solana-pubkey 3.0.0",
  "spl-discriminator 0.5.1",
  "spl-pod 0.7.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11900,7 +11954,7 @@ dependencies = [
  "solana-program-pack 3.0.0",
  "solana-pubkey 3.0.0",
  "solana-sdk-ids 3.1.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11921,7 +11975,7 @@ dependencies = [
  "spl-discriminator 0.4.1",
  "spl-pod 0.5.1",
  "spl-type-length-value 0.8.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11940,7 +11994,7 @@ dependencies = [
  "spl-discriminator 0.5.1",
  "spl-pod 0.7.1",
  "spl-type-length-value 0.9.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11965,7 +12019,7 @@ dependencies = [
  "spl-program-error 0.7.0",
  "spl-tlv-account-resolution 0.10.0",
  "spl-type-length-value 0.8.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -11991,7 +12045,7 @@ dependencies = [
  "spl-program-error 0.8.0",
  "spl-tlv-account-resolution 0.11.1",
  "spl-type-length-value 0.9.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12009,7 +12063,7 @@ dependencies = [
  "solana-program-error 2.2.2",
  "spl-discriminator 0.4.1",
  "spl-pod 0.5.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12027,7 +12081,7 @@ dependencies = [
  "solana-program-error 3.0.0",
  "spl-discriminator 0.5.1",
  "spl-pod 0.7.1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12102,7 +12156,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12130,9 +12184,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -12174,7 +12228,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12264,11 +12318,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -12279,18 +12333,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12419,7 +12473,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12703,7 +12757,7 @@ dependencies = [
  "prettyplease 0.2.37",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12741,7 +12795,7 @@ dependencies = [
  "prost-build 0.14.1",
  "prost-types 0.14.1",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "tempfile",
  "tonic-build 0.14.2",
 ]
@@ -12866,7 +12920,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -12953,7 +13007,7 @@ dependencies = [
  "rustls 0.23.35",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "utf-8",
  "webpki-roots 0.26.11",
 ]
@@ -13255,7 +13309,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -13398,7 +13452,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "solana-short-vec 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wincode-derive 0.1.1",
 ]
 
@@ -13411,8 +13465,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "solana-short-vec 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "wincode-derive 0.2.3",
+]
+
+[[package]]
+name = "wincode"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d967db7705dc29120bb6e8ce5b5a2e27734ed5976d1c904e95bd238d1c3c5a"
+dependencies = [
+ "pastey",
+ "proc-macro2",
+ "quote",
+ "thiserror 2.0.18",
+ "wincode-derive 0.4.6",
 ]
 
 [[package]]
@@ -13421,10 +13488,10 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a144d1576a6d65f9c80df1d531e12b197057c6f69a6e9d4a183fe61e9f135568"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13433,10 +13500,22 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8961eb04054a1b2e026b5628e24da7e001350249a787e1a85aa961f33dc5f286"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "wincode-derive"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13460,7 +13539,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13471,7 +13550,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -13896,9 +13975,9 @@ dependencies = [
  "solana-clock 3.0.0",
  "solana-commitment-config",
  "solana-hash 4.0.1",
- "solana-pubkey 4.0.0",
+ "solana-pubkey 4.2.0",
  "solana-signature 3.1.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",
  "yellowstone-grpc-proto",
@@ -13928,7 +14007,7 @@ dependencies = [
  "serde_with",
  "serde_yaml",
  "solana-clock 3.0.0",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
@@ -13943,14 +14022,17 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "12.2.0"
+version = "13.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b250b0ed11fb0fb11b80e89599e6f5a77640bce3dafe26ffb8022cdfc6c49e"
+checksum = "ad8d3827e1b27fe865ded7a4b1afdab34fbd427f9ffdd966a7c17c9fcde43181"
 dependencies = [
+ "arc-swap",
  "bytes",
  "futures 0.3.31",
  "hyper-util",
- "thiserror 2.0.17",
+ "log",
+ "pin-project",
+ "thiserror 2.0.18",
  "tokio",
  "tonic 0.14.2",
  "tonic-health",
@@ -13960,14 +14042,17 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "12.1.0"
+version = "12.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab52445da59c3e710dd2128e3e49598cfa45c8ba7f30feb608cafbd404e5e8cf"
+checksum = "c91071690a2b0a078a4712ecca7be37aa929b474a74f4f269c61582f8e2a6139"
 dependencies = [
  "anyhow",
  "prost 0.14.1",
  "prost-types 0.14.1",
  "protoc-bin-vendored",
+ "siphasher 1.0.1",
+ "solana-pubkey 4.2.0",
+ "thiserror 2.0.18",
  "tonic 0.14.2",
  "tonic-prost",
  "tonic-prost-build",
@@ -14268,7 +14353,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.111",
+ "syn 2.0.118",
  "yellowstone-vixen-core",
 ]
 
@@ -14459,6 +14544,7 @@ dependencies = [
  "futures-util",
  "serde",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",
@@ -14485,7 +14571,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -14506,7 +14592,7 @@ checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -14526,7 +14612,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
  "synstructure 0.13.2",
 ]
 
@@ -14547,7 +14633,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -14580,7 +14666,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 authors = ["Triton One", "ABK-Labs", "Jupiter Exchange"]
 edition = "2024"
 license = "MIT"
-version = "0.6.2"
+version = "0.7.0"
 repository = "https://github.com/rpcpool/yellowstone-vixen"
 publish = false
 
@@ -108,31 +108,31 @@ yellowstone-grpc-proto = { version = "12.4", default-features = false }
 rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "zstd"] }
 reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }
 
-yellowstone-vixen = { path = "crates/runtime", version = "0.6.1" }
-yellowstone-vixen-proc-macro = { path = "crates/proc-macro", version = "0.6.1" }
-yellowstone-vixen-stream = { path = "crates/stream", version = "0.6.1" }
-yellowstone-vixen-core = { path = "crates/core", version = "0.6.1" }
-yellowstone-vixen-mock = { path = "crates/mock", version = "0.6.1" }
-yellowstone-vixen-parser = { path = "crates/parser", version = "0.6.1" }
-yellowstone-vixen-proto = { path = "crates/proto", version = "0.6.1" }
+yellowstone-vixen = { path = "crates/runtime", version = "0.7.0" }
+yellowstone-vixen-proc-macro = { path = "crates/proc-macro", version = "0.7.0" }
+yellowstone-vixen-stream = { path = "crates/stream", version = "0.7.0" }
+yellowstone-vixen-core = { path = "crates/core", version = "0.7.0" }
+yellowstone-vixen-mock = { path = "crates/mock", version = "0.7.0" }
+yellowstone-vixen-parser = { path = "crates/parser", version = "0.7.0" }
+yellowstone-vixen-proto = { path = "crates/proto", version = "0.7.0" }
 
 # Parsers
-yellowstone-vixen-bpf-loader-parser = { path = "crates/bpf-loader-parser", version = "0.6.1" }
-yellowstone-vixen-spl-token-extensions-parser = { path = "crates/spl-token-extensions-parser", version = "0.6.1" }
-yellowstone-vixen-spl-token-parser = { path = "crates/spl-token-parser", version = "0.6.1" }
-yellowstone-vixen-block-meta-parser = { path = "crates/block-meta-parser", version = "0.6.1" }
-yellowstone-vixen-slot-parser = { path = "crates/slot-parser", version = "0.6.1" }
-yellowstone-vixen-stake-pool-parser = { path = "crates/stake-pool-parser", version = "0.6.1" }
+yellowstone-vixen-bpf-loader-parser = { path = "crates/bpf-loader-parser", version = "0.7.0" }
+yellowstone-vixen-spl-token-extensions-parser = { path = "crates/spl-token-extensions-parser", version = "0.7.0" }
+yellowstone-vixen-spl-token-parser = { path = "crates/spl-token-parser", version = "0.7.0" }
+yellowstone-vixen-block-meta-parser = { path = "crates/block-meta-parser", version = "0.7.0" }
+yellowstone-vixen-slot-parser = { path = "crates/slot-parser", version = "0.7.0" }
+yellowstone-vixen-stake-pool-parser = { path = "crates/stake-pool-parser", version = "0.7.0" }
 
 # Sources
-yellowstone-vixen-solana-rpc-source = { path = "crates/solana-rpc-source", version = "0.6.1" }
-yellowstone-vixen-yellowstone-grpc-source = { path = "crates/yellowstone-grpc-source", version = "0.6.1" }
-yellowstone-vixen-yellowstone-fumarole-source = { path = "crates/yellowstone-fumarole-source", version = "0.6.1" }
-yellowstone-vixen-solana-snapshot-source = { path = "crates/solana-snapshot-source", version = "0.6.1" }
-yellowstone-vixen-jetstream-source = { path = "crates/jetstreamer-source", version = "0.6.1" }
+yellowstone-vixen-solana-rpc-source = { path = "crates/solana-rpc-source", version = "0.7.0" }
+yellowstone-vixen-yellowstone-grpc-source = { path = "crates/yellowstone-grpc-source", version = "0.7.0" }
+yellowstone-vixen-yellowstone-fumarole-source = { path = "crates/yellowstone-fumarole-source", version = "0.7.0" }
+yellowstone-vixen-solana-snapshot-source = { path = "crates/solana-snapshot-source", version = "0.7.0" }
+yellowstone-vixen-jetstream-source = { path = "crates/jetstreamer-source", version = "0.7.0" }
 
 # Coordinators
-yellowstone-vixen-block-coordinator = { path = "crates/block-coordinator", version = "0.6.1" }
+yellowstone-vixen-block-coordinator = { path = "crates/block-coordinator", version = "0.7.0" }
 
 # Sinks
-yellowstone-vixen-kafka-sink = { path = "crates/kafka-sink", version = "0.6.0" }
+yellowstone-vixen-kafka-sink = { path = "crates/kafka-sink", version = "0.7.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,8 +103,8 @@ warp = "0.3"
 
 yellowstone-block-machine = { version = "0.4.0" }
 yellowstone-fumarole-client = "0.4.0+solana.3"
-yellowstone-grpc-client = { version = "12" }
-yellowstone-grpc-proto = { version = "12", default-features = false }
+yellowstone-grpc-client = { version = "13.1" }
+yellowstone-grpc-proto = { version = "12.4", default-features = false }
 rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "zstd"] }
 reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }
 

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ To use it, add the following dependencies to your `Cargo.toml`:
 ```toml
 [dependencies]
 borsh = "^1.0.0"
-yellowstone-vixen-parser = { version = "0.6.0" }
-yellowstone-vixen-proc-macro = { version = "0.6.0" }
+yellowstone-vixen-parser = { version = "0.7.0" }
+yellowstone-vixen-proc-macro = { version = "0.7.0" }
 ```
 
 Then, import and invoke the macro in your code. Specify the path to your Codama JSON IDL file relative to your crate root:

--- a/Vixen.example.toml
+++ b/Vixen.example.toml
@@ -15,6 +15,24 @@ x-token = "<X-TOKEN>"
 # This defines how long to wait for a connection before timing out.
 timeout = 60
 
+# Built-in auto-reconnect for the gRPC stream.
+# When enabled (the default), the stream reconnects with exponential backoff
+# after a transient failure, resumes from the last seen slot, and deduplicates
+# replayed events. The server must have `replay_stored_slots` configured for
+# gap-free recovery. Set to false to disable reconnect entirely.
+#auto-reconnect = true
+
+# Maximum reconnect attempts before the stream gives up.
+# Only applies when auto-reconnect is enabled. Defaults to 10, which with the
+# 500ms/2.0x backoff covers outages up to ~4 minutes. Increase for longer
+# tolerated outages.
+#reconnect-max-retries = 10
+
+# Number of recent slots retained for deduplication during the replay window.
+# Only applies when auto-reconnect is enabled. Defaults to the client library
+# value; raise it if your replay window is large.
+#reconnect-slot-retention = 150
+
 # # Only needed if you are using Fumarole as a source.
 # [source]
 # endpoint = "https://index.rpcpool.com"

--- a/crates/block-coordinator/src/source.rs
+++ b/crates/block-coordinator/src/source.rs
@@ -154,15 +154,20 @@ impl SourceTrait for CoordinatorSource {
             .unwrap_or("CoordinatorSource");
         let timeout = Duration::from_secs(config.timeout);
 
-        let mut client = GeyserGrpcClient::build_from_shared(config.endpoint.clone())?
+        let mut builder = GeyserGrpcClient::build_from_shared(config.endpoint.clone())?
             .x_token(config.x_token.clone())?
             .max_decoding_message_size(config.max_decoding_message_size.unwrap_or(usize::MAX))
             .accept_compressed(config.accept_compression.unwrap_or_default().into())
             .connect_timeout(timeout)
             .timeout(timeout)
-            .tls_config(ClientTlsConfig::new().with_native_roots())?
-            .connect()
-            .await?;
+            .tls_config(ClientTlsConfig::new().with_native_roots())?;
+
+        if let Some(reconnect_config) = config.reconnect_config() {
+            tracing::info!(source_label, ?reconnect_config, "Auto-reconnect enabled");
+            builder = builder.set_reconnect_config(reconnect_config);
+        }
+
+        let mut client = builder.connect().await?;
 
         let subscribe_request = SubscribeRequest::from(self.filters.clone())
             .with_coordinator_subscriptions()

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -948,6 +948,7 @@ impl From<Filters> for SubscribeRequest {
                         filters: vec![],
                         // We receive all accounts updates
                         nonempty_txn_signature: None,
+                        cuckoo_accounts_filter: None,
                     }))
                 })
                 .collect(),
@@ -983,6 +984,7 @@ impl From<Filters> for SubscribeRequest {
                             .iter()
                             .map(ToString::to_string)
                             .collect(),
+                        token_accounts: None,
                     }))
                 })
                 .collect(),
@@ -1002,6 +1004,7 @@ impl From<Filters> for SubscribeRequest {
                         include_transactions: Some(v.include_transactions),
                         include_accounts: Some(v.include_accounts),
                         include_entries: Some(v.include_entries),
+                        cuckoo_account_include: None,
                     }))
                 })
                 .collect(),

--- a/crates/jetstreamer-source/src/lib.rs
+++ b/crates/jetstreamer-source/src/lib.rs
@@ -1321,6 +1321,7 @@ mod convert {
                     post_balance: info.post_balance,
                     reward_type,
                     commission: info.commission.map(|c| c.to_string()).unwrap_or_default(),
+                    commission_bps: String::new(),
                 }
             })
             .collect();
@@ -1458,6 +1459,7 @@ mod convert {
                         _ => proto::RewardType::Unspecified as i32,
                     },
                     commission: r.commission.map(|c| c.to_string()).unwrap_or_default(),
+                    commission_bps: String::new(),
                 })
                 .collect(),
             loaded_writable_addresses: meta

--- a/crates/proc-macro/README.md
+++ b/crates/proc-macro/README.md
@@ -9,8 +9,8 @@ Add this crate to your `Cargo.toml` (usually as a `proc-macro` dependency):
 ```toml
 [dependencies]
 borsh = { version = "^1.0.0", features = ["derive"] }
-yellowstone-vixen-parser = { version = "0.6.0" }
-yellowstone-vixen-proc-macro = { version = "0.6.0" }
+yellowstone-vixen-parser = { version = "0.7.0" }
+yellowstone-vixen-proc-macro = { version = "0.7.0" }
 ```
 
 Then, in your code:

--- a/crates/yellowstone-grpc-source/Cargo.toml
+++ b/crates/yellowstone-grpc-source/Cargo.toml
@@ -19,3 +19,6 @@ yellowstone-grpc-proto = { workspace = true }
 yellowstone-grpc-client = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 clap = { workspace = true, features = ["derive", "cargo", "wrap_help"] }
+
+[dev-dependencies]
+toml = { workspace = true }

--- a/crates/yellowstone-grpc-source/src/lib.rs
+++ b/crates/yellowstone-grpc-source/src/lib.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use clap::ValueEnum;
 use futures_util::StreamExt;
 use tokio::sync::{mpsc::Sender, oneshot};
-use yellowstone_grpc_client::GeyserGrpcClient;
+use yellowstone_grpc_client::{Backoff, GeyserGrpcClient, ReconnectConfig};
 use yellowstone_grpc_proto::{
     geyser::{SubscribeRequest, SubscribeUpdate},
     tonic::{codec::CompressionEncoding, transport::ClientTlsConfig, Status},
@@ -32,6 +32,16 @@ impl From<VixenCompressionEncoding> for CompressionEncoding {
     }
 }
 
+const fn default_auto_reconnect() -> bool { true }
+
+/// Reconnect defaults, deliberately sturdier than the client library's
+/// (3 retries / 10ms base), which gives up in under ~100ms. With these,
+/// 10 retries doubling from 500ms cover outages up to ~4 minutes
+/// (500ms, 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s).
+const DEFAULT_RECONNECT_MAX_RETRIES: u32 = 10;
+const DEFAULT_RECONNECT_INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+const DEFAULT_RECONNECT_MULTIPLIER: f64 = 2.0;
+
 /// Yellowstone connection configuration.
 #[derive(Debug, clap::Args, serde::Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
@@ -57,6 +67,79 @@ pub struct YellowstoneGrpcConfig {
 
     #[arg(long, env)]
     pub accept_compression: Option<VixenCompressionEncoding>,
+
+    /// Enable the client's built-in auto-reconnect on the gRPC stream.
+    ///
+    /// When enabled, the stream reconnects with exponential backoff after a
+    /// transient failure, resumes from the last seen slot, and deduplicates
+    /// replayed events. The server must have `replay_stored_slots` configured
+    /// for gap-free recovery.
+    ///
+    /// Defaults to `true`: a config file omitting this key (including ones that
+    /// predate the field) gets auto-reconnect. Set to `false` to opt out.
+    #[arg(long, env, default_value_t = true)]
+    #[serde(default = "default_auto_reconnect")]
+    pub auto_reconnect: bool,
+
+    /// Max reconnect attempts before the stream gives up.
+    ///
+    /// Only applies when `auto_reconnect` is set. Falls back to the client
+    /// library default when unset.
+    #[arg(long, env)]
+    pub reconnect_max_retries: Option<u32>,
+
+    /// Number of recent slots retained for dedup during the replay window.
+    ///
+    /// Only applies when `auto_reconnect` is set. Falls back to the client
+    /// library default when unset.
+    #[arg(long, env)]
+    pub reconnect_slot_retention: Option<usize>,
+}
+
+impl YellowstoneGrpcConfig {
+    /// Build the auto-reconnect config from the user-facing flags.
+    ///
+    /// Uses sturdier backoff defaults than the client library (see
+    /// [`DEFAULT_RECONNECT_MAX_RETRIES`] and friends); `reconnect_max_retries`
+    /// and `reconnect_slot_retention` override the retry count and dedup window.
+    ///
+    /// Example output:
+    /// ```rust, ignore
+    /// // auto_reconnect = false
+    /// assert!(config.reconnect_config().is_none());
+    ///
+    /// // auto_reconnect = true, no overrides -> sturdy defaults
+    /// let rc = config.reconnect_config().unwrap();
+    /// assert_eq!(rc.backoff.max_retries, 10);
+    /// assert_eq!(rc.backoff.multiplier, 2.0);
+    /// ```
+    ///
+    /// Returns `None` when auto-reconnect is disabled.
+    pub fn reconnect_config(&self) -> Option<ReconnectConfig> {
+        if !self.auto_reconnect {
+            return None;
+        }
+
+        let max_retries = self
+            .reconnect_max_retries
+            .unwrap_or(DEFAULT_RECONNECT_MAX_RETRIES);
+
+        let backoff = Backoff::new(
+            DEFAULT_RECONNECT_INITIAL_BACKOFF,
+            DEFAULT_RECONNECT_MULTIPLIER,
+            max_retries,
+        );
+
+        // Start from the library default for fields we keep (slot_retention),
+        // then swap in the sturdier backoff.
+        let mut config = ReconnectConfig::default().with_backoff(backoff);
+
+        if let Some(slot_retention) = self.reconnect_slot_retention {
+            config.slot_retention = slot_retention;
+        }
+
+        Some(config)
+    }
 }
 
 /// A `Source` implementation for the Yellowstone gRPC API.
@@ -81,15 +164,20 @@ impl SourceTrait for YellowstoneGrpcSource {
         let config = self.config.clone();
         let timeout = Duration::from_secs(config.timeout);
 
-        let mut client = GeyserGrpcClient::build_from_shared(config.endpoint.clone())?
+        let mut builder = GeyserGrpcClient::build_from_shared(config.endpoint.clone())?
             .x_token(config.x_token.clone())?
             .max_decoding_message_size(config.max_decoding_message_size.unwrap_or(usize::MAX))
             .accept_compressed(config.accept_compression.unwrap_or_default().into())
             .connect_timeout(timeout)
             .timeout(timeout)
-            .tls_config(ClientTlsConfig::new().with_native_roots())?
-            .connect()
-            .await?;
+            .tls_config(ClientTlsConfig::new().with_native_roots())?;
+
+        if let Some(reconnect_config) = config.reconnect_config() {
+            tracing::debug!(?reconnect_config, "Auto-reconnect enabled");
+            builder = builder.set_reconnect_config(reconnect_config);
+        }
+
+        let mut client = builder.connect().await?;
 
         let mut subscribe_request: SubscribeRequest = filters.into();
         if let Some(from_slot) = config.from_slot {
@@ -145,5 +233,90 @@ impl SourceTrait for YellowstoneGrpcSource {
         let _ = status_tx.send(exit_status);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::YellowstoneGrpcConfig;
+
+    /// A config file predating the reconnect fields must still deserialize:
+    /// missing `Option` keys become `None`, and the missing `auto-reconnect`
+    /// key defaults to `true` via `#[serde(default = "default_auto_reconnect")]`,
+    /// so legacy configs get auto-reconnect.
+    #[test]
+    fn deserializes_legacy_config_with_reconnect_on_by_default() {
+        let legacy = r#"
+            endpoint = "https://example.rpcpool.com"
+            x-token = "secret"
+            timeout = 60
+        "#;
+
+        let config: YellowstoneGrpcConfig =
+            toml::from_str(legacy).expect("legacy config must deserialize");
+
+        assert!(config.auto_reconnect);
+        assert!(config.reconnect_config().is_some());
+    }
+
+    /// Auto-reconnect can be explicitly disabled.
+    #[test]
+    fn reconnect_can_be_disabled() {
+        let disabled = r#"
+            endpoint = "https://example.rpcpool.com"
+            timeout = 60
+            auto-reconnect = false
+        "#;
+
+        let config: YellowstoneGrpcConfig =
+            toml::from_str(disabled).expect("config must deserialize");
+
+        assert!(!config.auto_reconnect);
+        assert!(config.reconnect_config().is_none());
+    }
+
+    /// With no overrides, the helper yields the sturdy built-in defaults
+    /// (not the weak library defaults), and keeps the library slot_retention.
+    #[test]
+    fn reconnect_config_uses_sturdy_defaults() {
+        let config: YellowstoneGrpcConfig = toml::from_str(
+            r#"
+            endpoint = "https://example.rpcpool.com"
+            timeout = 60
+            auto-reconnect = true
+        "#,
+        )
+        .expect("config must deserialize");
+
+        let reconnect = config.reconnect_config().expect("auto-reconnect enabled");
+
+        assert_eq!(reconnect.backoff.max_retries, super::DEFAULT_RECONNECT_MAX_RETRIES);
+        assert_eq!(reconnect.backoff.multiplier, super::DEFAULT_RECONNECT_MULTIPLIER);
+        assert_eq!(reconnect.backoff.initial_interval, super::DEFAULT_RECONNECT_INITIAL_BACKOFF);
+        // slot_retention is not overridden, so it keeps the library default.
+        assert_eq!(
+            reconnect.slot_retention,
+            yellowstone_grpc_client::ReconnectConfig::default().slot_retention
+        );
+    }
+
+    /// Config overrides win over the built-in defaults.
+    #[test]
+    fn reconnect_config_applies_overrides() {
+        let config: YellowstoneGrpcConfig = toml::from_str(
+            r#"
+            endpoint = "https://example.rpcpool.com"
+            timeout = 60
+            auto-reconnect = true
+            reconnect-max-retries = 25
+            reconnect-slot-retention = 300
+        "#,
+        )
+        .expect("config must deserialize");
+
+        let reconnect = config.reconnect_config().expect("auto-reconnect enabled");
+
+        assert_eq!(reconnect.backoff.max_retries, 25);
+        assert_eq!(reconnect.slot_retention, 300);
     }
 }

--- a/crates/yellowstone-grpc-source/src/lib.rs
+++ b/crates/yellowstone-grpc-source/src/lib.rs
@@ -290,9 +290,18 @@ mod tests {
 
         let reconnect = config.reconnect_config().expect("auto-reconnect enabled");
 
-        assert_eq!(reconnect.backoff.max_retries, super::DEFAULT_RECONNECT_MAX_RETRIES);
-        assert_eq!(reconnect.backoff.multiplier, super::DEFAULT_RECONNECT_MULTIPLIER);
-        assert_eq!(reconnect.backoff.initial_interval, super::DEFAULT_RECONNECT_INITIAL_BACKOFF);
+        assert_eq!(
+            reconnect.backoff.max_retries,
+            super::DEFAULT_RECONNECT_MAX_RETRIES
+        );
+        assert_eq!(
+            reconnect.backoff.multiplier,
+            super::DEFAULT_RECONNECT_MULTIPLIER
+        );
+        assert_eq!(
+            reconnect.backoff.initial_interval,
+            super::DEFAULT_RECONNECT_INITIAL_BACKOFF
+        );
         // slot_retention is not overridden, so it keeps the library default.
         assert_eq!(
             reconnect.slot_retention,


### PR DESCRIPTION
Closes #269

## Changes
- Bump yellowstone-grpc-client 12 → 13.1, proto 12 → 12.4
- Add required proto fields (cuckoo filters, token_accounts, commission_bps)
- Auto-reconnect enabled by default with production-grade backoff (500ms × 2.0, 10 retries, ~4min coverage)
- Configurable via `auto-reconnect`, `reconnect-max-retries`, `reconnect-slot-retention` in Vixen.toml
- Set `auto-reconnect = false` to opt out

## Breaking
- Workspace version bumped to 0.7.0
- `YellowstoneGrpcConfig` has new public fields (backward-compatible via serde defaults)

## Tested
- cargo build/test clean (208 tests, 0 failures)
- Live smoke test: 35K+ parsed events on mainnet
- Forced-disconnect reconnect: gap-free resume confirmed

Partially addresses #134 (tonic 0.14)
