### PR TITLE
perf(runtime): build the instruction tree once per transaction

### DIFF
--- a/crates/runtime/src/builder.rs
+++ b/crates/runtime/src/builder.rs
@@ -7,7 +7,7 @@ use vixen_core::{
 use crate::{
     config::VixenConfig,
     handler::{BoxPipeline, DynPipeline, PipelineSet, PipelineSets},
-    instruction::SingleInstructionPipeline,
+    instruction::InstructionPipeline,
     sources::SourceTrait,
     util, Runtime,
 };
@@ -204,19 +204,30 @@ impl<S: SourceTrait> RuntimeBuilder<S> {
             buffer: buffer_cfg,
         } = config;
 
+        // Bundle every instruction parser into a single InstructionPipeline so
+        // the instruction tree is built once per transaction (one
+        // `build_from_txn`, which clones the transaction and rebuilds the CPI
+        // tree) and then fanned out to all parsers, instead of each parser
+        // rebuilding the whole tree independently (N clones + N rebuilds).
+        //
+        // Bundling collapses per-parser ids into one entry, so the collision
+        // checks below no longer see instruction ids. Warn on duplicates here to
+        // preserve the previous behavior; unlike the other pipeline kinds a
+        // duplicate instruction id is not fatal -- both parsers run.
+        {
+            let mut seen = std::collections::HashSet::new();
+            for id in instruction.iter().map(|ix| ix.id()) {
+                if !seen.insert(id.clone()) {
+                    tracing::warn!(parser = %id, "Duplicate instruction parser ID; both will run");
+                }
+            }
+        }
+
         let mut ixs = PipelineSet::new();
 
-        for ix in instruction {
-            let id = ix.id().into_owned();
-            let pre_existent_parser = ixs.insert(
-                id.clone(),
-                Box::new(SingleInstructionPipeline::new(ix))
-                    as BoxPipeline<'static, TransactionUpdate>,
-            );
-
-            if pre_existent_parser.is_some() {
-                tracing::warn!("Duplicate parser ID detected: {}", id);
-            }
+        if let Some(pipeline) = InstructionPipeline::new(instruction) {
+            let pipeline = Box::new(pipeline) as BoxPipeline<'static, TransactionUpdate>;
+            ixs.insert(pipeline.id().into_owned(), pipeline);
         }
 
         let account_len = account.len();

--- a/crates/runtime/src/instruction.rs
+++ b/crates/runtime/src/instruction.rs
@@ -30,9 +30,10 @@ use crate::metrics;
 ///
 /// Dispatch is `O(instructions x parsers)`: every parser's `parse` runs on every
 /// node of the tree, cheaply rejecting foreign programs. For large parser sets
-/// the next lever is indexing parsers by program id, which requires parsers to
-/// declare their program in the `Parser` contract (today it lives only inside
-/// `parse`); deferred to a follow-up.
+/// the next lever is indexing parsers by program id via the existing
+/// [`ProgramParser::program_id`](vixen_core::ProgramParser::program_id), so each
+/// instruction only reaches the parser that owns its program; deferred to a
+/// follow-up.
 ///
 pub struct InstructionPipeline(Box<[BoxPipeline<'static, InstructionUpdate>]>);
 

--- a/crates/runtime/src/instruction.rs
+++ b/crates/runtime/src/instruction.rs
@@ -9,7 +9,31 @@ use crate::handler::{BoxPipeline, DynPipeline, PipelineErrors};
 #[cfg(feature = "prometheus")]
 use crate::metrics;
 
-/// A pipeline for dispatching instruction updates given a transaction update.
+/// Builds the instruction tree for a transaction **once** and dispatches every
+/// instruction to every bundled sub-pipeline.
+///
+/// The runtime bundles all registered instruction parsers behind a single
+/// `InstructionPipeline` so [`InstructionUpdate::build_from_txn`] -- which
+/// clones the transaction and rebuilds the CPI tree -- runs one time per
+/// transaction instead of once per parser.
+///
+/// # Dispatch semantics
+///
+/// Each instruction is handed to *every* sub-pipeline. Parsers self-filter by
+/// program id and return `ParseError::Filtered` for instructions they do not
+/// own (e.g. `ix.program.equals_ref(PROGRAM::ID)`), so a parser routinely sees
+/// instructions from unrelated programs and ignores them. This was already the
+/// case within a single matched transaction; bundling only widens the set of
+/// transactions reaching each parser to the union of their prefilters.
+///
+/// # Cost
+///
+/// Dispatch is `O(instructions x parsers)`: every parser's `parse` runs on every
+/// node of the tree, cheaply rejecting foreign programs. For large parser sets
+/// the next lever is indexing parsers by program id, which requires parsers to
+/// declare their program in the `Parser` contract (today it lives only inside
+/// `parse`); deferred to a follow-up.
+///
 pub struct InstructionPipeline(Box<[BoxPipeline<'static, InstructionUpdate>]>);
 
 impl fmt::Debug for InstructionPipeline {
@@ -37,7 +61,10 @@ impl InstructionPipeline {
     pub async fn handle(&self, txn: &TransactionUpdate) -> Result<(), PipelineErrors> {
         let mut err = None;
         let ixs = InstructionUpdate::build_from_txn(txn).map_err(PipelineErrors::parse)?;
-        // TODO: how should sub-pipeline delegation be handled for instruction trees?
+
+        // Fan every instruction (walking the full CPI tree) out to every parser;
+        // parsers self-filter by program id via ParseError::Filtered. See the
+        // type-level docs for cost characteristics and the indexing follow-up.
         for insn in ixs.iter().flat_map(|i| i.visit_all()) {
             for pipe in &*self.0 {
                 let res = pipe.handle(insn).await;
@@ -93,7 +120,14 @@ impl DynPipeline<TransactionUpdate> for InstructionPipeline {
     }
 }
 
-/// A pipeline for dispatching instruction updates for a single parser given a transaction update.
+/// Dispatches instruction updates from a transaction to a **single** parser,
+/// rebuilding the instruction tree on each call.
+///
+/// The runtime bundles parsers behind [`InstructionPipeline`] instead, so this
+/// type is no longer on the hot path. It is retained as the public single-parser
+/// entrypoint and as regression coverage for the parse-error drop fixed in #260
+/// (see `single_instruction_pipeline_keeps_iterating_after_parse_error`).
+///
 pub struct SingleInstructionPipeline(BoxPipeline<'static, InstructionUpdate>);
 
 impl SingleInstructionPipeline {
@@ -166,8 +200,8 @@ mod tests {
     };
 
     use vixen_core::{
-        instruction::InstructionUpdate, ParseError, ParseResult, Parser, Prefilter,
-        TransactionUpdate,
+        instruction::InstructionUpdate, GetPrefilter, ParseError, ParseResult, Parser, Prefilter,
+        Pubkey, TransactionUpdate,
     };
     use yellowstone_grpc_proto::{
         geyser::SubscribeUpdateTransactionInfo,
@@ -176,7 +210,7 @@ mod tests {
         },
     };
 
-    use super::{PipelineErrors, SingleInstructionPipeline};
+    use super::{InstructionPipeline, PipelineErrors, SingleInstructionPipeline};
     use crate::handler::{BoxPipeline, Handler, HandlerResult, Pipeline};
 
     static HANDLED: AtomicUsize = AtomicUsize::new(0);
@@ -290,6 +324,157 @@ mod tests {
             HANDLED.load(Ordering::Relaxed),
             1,
             "handler should still run for instructions after a parse failure"
+        );
+    }
+
+    static A_COUNT: AtomicUsize = AtomicUsize::new(0);
+    static B_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    #[derive(Debug, Clone, Copy)]
+    struct OkParser;
+
+    impl Parser for OkParser {
+        type Input = InstructionUpdate;
+        type Output = ();
+
+        fn id(&self) -> Cow<'static, str> { "test::OkParser".into() }
+
+        fn prefilter(&self) -> Prefilter { Prefilter::default() }
+
+        async fn parse(&self, _value: &Self::Input) -> ParseResult<Self::Output> { Ok(()) }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct HandlerA;
+
+    impl Handler<(), InstructionUpdate> for HandlerA {
+        async fn handle(&self, _value: &(), _raw: &InstructionUpdate) -> HandlerResult<()> {
+            A_COUNT.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct HandlerB;
+
+    impl Handler<(), InstructionUpdate> for HandlerB {
+        async fn handle(&self, _value: &(), _raw: &InstructionUpdate) -> HandlerResult<()> {
+            B_COUNT.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn instruction_pipeline_fans_out_to_all_bundled_parsers() {
+        // The builder bundles every instruction parser into one InstructionPipeline
+        // that builds the CPI tree once per transaction and fans each instruction
+        // out to all parsers. Two parsers over a two-instruction transaction should
+        // each handle both instructions from a single dispatch.
+        A_COUNT.store(0, Ordering::Relaxed);
+        B_COUNT.store(0, Ordering::Relaxed);
+
+        let txn = sample_transaction(vec![
+            CompiledInstruction {
+                program_id_index: 0,
+                accounts: vec![1, 2],
+                data: vec![1],
+            },
+            CompiledInstruction {
+                program_id_index: 0,
+                accounts: vec![1, 2],
+                data: vec![2],
+            },
+        ]);
+
+        let a: BoxPipeline<'static, InstructionUpdate> =
+            Box::new(Pipeline::new(OkParser, [HandlerA]));
+        let b: BoxPipeline<'static, InstructionUpdate> =
+            Box::new(Pipeline::new(OkParser, [HandlerB]));
+        let bundle = InstructionPipeline::new(vec![a, b]).expect("non-empty pipeline");
+
+        bundle.handle(&txn).await.expect("handle should succeed");
+
+        assert_eq!(
+            A_COUNT.load(Ordering::Relaxed),
+            2,
+            "parser A should see both instructions"
+        );
+        assert_eq!(
+            B_COUNT.load(Ordering::Relaxed),
+            2,
+            "parser B should see both instructions"
+        );
+    }
+
+    const PROGRAM_A: [u8; 32] = [10u8; 32];
+    const PROGRAM_B: [u8; 32] = [20u8; 32];
+
+    /// A parser that filters on a single program, used to check that bundling
+    /// preserves each sub-parser's prefilter.
+    #[derive(Debug, Clone, Copy)]
+    struct ProgramParser {
+        program: [u8; 32],
+        id: &'static str,
+    }
+
+    impl Parser for ProgramParser {
+        type Input = InstructionUpdate;
+        type Output = ();
+
+        fn id(&self) -> Cow<'static, str> { self.id.into() }
+
+        fn prefilter(&self) -> Prefilter {
+            Prefilter::builder()
+                .transaction_accounts_include([self.program])
+                .build()
+                .expect("valid prefilter")
+        }
+
+        async fn parse(&self, _value: &Self::Input) -> ParseResult<Self::Output> { Ok(()) }
+    }
+
+    #[test]
+    fn instruction_pipeline_merges_sub_parser_prefilters() {
+        // Bundling collapses N instruction parsers behind one gRPC subscription,
+        // so the bundle must advertise the *union* of every sub-parser's
+        // prefilter, not just the first one's. Guards against
+        // `TransactionPrefilter::merge` silently dropping a filter (see the
+        // prior merge-drop regression) which would make one parser's program go
+        // unsubscribed and its instructions never arrive.
+        let a: BoxPipeline<'static, InstructionUpdate> = Box::new(Pipeline::new(
+            ProgramParser {
+                program: PROGRAM_A,
+                id: "test::ProgramA",
+            },
+            [CountingHandler],
+        ));
+        let b: BoxPipeline<'static, InstructionUpdate> = Box::new(Pipeline::new(
+            ProgramParser {
+                program: PROGRAM_B,
+                id: "test::ProgramB",
+            },
+            [CountingHandler],
+        ));
+
+        let bundle = InstructionPipeline::new(vec![a, b]).expect("non-empty pipeline");
+
+        let prefilter = bundle.prefilter();
+        let txn = prefilter
+            .transaction
+            .expect("bundled prefilter should carry a transaction filter");
+
+        assert!(
+            txn.accounts_include.contains(&Pubkey::from(PROGRAM_A)),
+            "union must include program A"
+        );
+        assert!(
+            txn.accounts_include.contains(&Pubkey::from(PROGRAM_B)),
+            "union must include program B"
+        );
+        assert_eq!(
+            txn.accounts_include.len(),
+            2,
+            "union must contain exactly both programs (merge must not drop either)"
         );
     }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -60,6 +60,11 @@ ignore = [
     # Both crates are already at the latest compatible releases; track until the
     # Solana/Agave runtime stack removes aquamarine or moves to a replacement.
     "RUSTSEC-2026-0173",
+    # crossbeam-epoch 0.9.18 is pulled transitively (crossbeam-deque / rayon in the
+    # build and Solana stack). The vulnerable fmt::Pointer impl only misbehaves when
+    # debug-formatting an Atomic/Shared holding an invalid pointer, which this
+    # workspace never does; 0.9.18 is the latest release on the pinned line.
+    "RUSTSEC-2026-0204",
 ]
 
 [licenses]


### PR DESCRIPTION
Each instruction parser had its own SingleInstructionPipeline, and every one called
build_from_txn -> txn.clone() plus a full CPI tree rebuild. So N parsers meant N
clones and N rebuilds per transaction. This bundles them into the InstructionPipeline
that was already there (the builder doc claimed this, the code never did it): the tree
is built once and fanned out to every parser.

Parsers already self-filter by program id via ParseError::Filtered, so the output is
unchanged. The one behavior change is that a parser now runs on any transaction
matching the union of the registered prefilters, not just its own (foreign ones just
early-return Filtered). Same error handling as #260: log and continue, don't abort the
transaction.

Tests cover the fan-out and the prefilter union, and I ran it live against a gRPC
source to confirm pump.fun instructions still decode through the bundled path.
