### PR TITLE
Supports inline structs

### DIFF
--- a/crates/block-coordinator/src/types.rs
+++ b/crates/block-coordinator/src/types.rs
@@ -189,29 +189,23 @@ impl fmt::Display for ColorSlot {
 }
 
 /// Account commitment configuration.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum AccountCommitAt {
     /// Accounts flush when the slot is confirmed (same timing as instructions).
+    #[default]
     Confirmed,
     /// Accounts flush when the slot is finalized.
     Finalized,
 }
 
-impl Default for AccountCommitAt {
-    fn default() -> Self { Self::Confirmed }
-}
-
 /// How accounts are processed and output.
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub enum AccountMode {
     /// Accounts in the same processed subscription. Commit triggered by a specific event.
     Processed { commit_at: AccountCommitAt },
     /// Separate finalized subscription, pass-through writes (no buffering).
+    #[default]
     FinalizedPassthrough,
-}
-
-impl Default for AccountMode {
-    fn default() -> Self { Self::FinalizedPassthrough }
 }
 
 /// An instruction slot ready for downstream consumption (e.g., Kafka write).

--- a/crates/kafka-sink/src/schema_registry.rs
+++ b/crates/kafka-sink/src/schema_registry.rs
@@ -224,18 +224,19 @@ pub fn ensure_schemas_registered(
     tracing::info!(url = %base_url, "Registering schemas with Schema Registry");
 
     for schema_def in schemas {
-        let schema_id = register_schema(&client, base_url, &schema_def.subject, schema_def.schema, config)
-            .or_else(|e| {
-                tracing::debug!(subject = %schema_def.subject, error = %e, "Registration failed, trying existing");
-                get_latest_schema_id_for_subject(&client, base_url, &schema_def.subject, config)
-                    .ok_or(e)
-            })
-            .map_err(|e| {
-                io::Error::other(format!(
-                    "No schema available for {}: {e}",
-                    schema_def.subject
-                ))
-            })?;
+        let schema_id = register_schema(
+            &client,
+            base_url,
+            &schema_def.subject,
+            schema_def.schema,
+            config,
+        )
+        .map_err(|e| {
+            io::Error::other(format!(
+                "Failed to register schema for {}: {e}",
+                schema_def.subject
+            ))
+        })?;
 
         tracing::debug!(subject = %schema_def.subject, schema_id, "Schema ready");
 
@@ -247,35 +248,45 @@ pub fn ensure_schemas_registered(
 
     Ok(registered)
 }
-
-fn get_latest_schema_id_for_subject(
-    client: &reqwest::blocking::Client,
-    base_url: &str,
-    subject: &str,
-    config: &KafkaSinkConfig,
-) -> Option<i32> {
-    let url = format!("{}/subjects/{}/versions/latest", base_url, subject);
-    let req = client.get(&url);
-    let req = config.apply_schema_registry_auth_if_configured(req);
-    let response = req.send().ok()?;
-
-    if response.status().is_success() {
-        #[derive(Deserialize)]
-        struct SchemaVersion {
-            id: i32,
-        }
-
-        let version: SchemaVersion = response.json().ok()?;
-
-        Some(version.id)
-    } else {
-        None
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn incompatible_schema_does_not_use_the_latest_schema_id() {
+        let mut server = mockito::Server::new();
+        let subject = "example-value";
+
+        server
+            .mock("GET", "/subjects")
+            .with_status(200)
+            .with_body("[]")
+            .create();
+        server
+            .mock("POST", "/subjects/example-value/versions")
+            .with_status(409)
+            .with_body(r#"{"error_code": 40901, "message": "Incompatible schema"}"#)
+            .create();
+        server
+            .mock("GET", "/subjects/example-value/versions/latest")
+            .with_status(200)
+            .with_body(r#"{"id": 42}"#)
+            .create();
+
+        let config = KafkaSinkConfig {
+            schema_registry_url: server.url(),
+            ..Default::default()
+        };
+        let schemas = [SchemaDefinition {
+            subject: subject.to_string(),
+            schema: "syntax = \"proto3\"; message Example {}",
+            message_index: 0,
+        }];
+
+        let error = ensure_schemas_registered(&config, &schemas).unwrap_err();
+
+        assert!(error.to_string().contains("Schema conflict (code 40901)"));
+    }
 
     #[test]
     fn schema_registry_auth_sends_basic_auth_header() {

--- a/crates/proc-macro/src/intermediate_representation/build_defined_types.rs
+++ b/crates/proc-macro/src/intermediate_representation/build_defined_types.rs
@@ -1,7 +1,7 @@
 use codama_nodes::{DefinedTypeNode, NestedTypeNode, TypeNode};
 
 use crate::intermediate_representation::{
-    helpers::{build_fields_ir, map_type_with_label},
+    helpers::{build_fields_ir, map_type_with_label, materialize_type},
     FieldIr, OneofIr, OneofVariantIr, SchemaIr, TypeIr, TypeKindIr,
 };
 
@@ -100,7 +100,12 @@ fn build_defined_type_tuple(
 ) {
     // Single-item tuples are inlined as their inner type (e.g. optionBool → bool).
     if tuple_type_node.items.len() == 1 {
-        let (_label, field_type) = map_type_with_label(&tuple_type_node.items[0]);
+        let (_label, field_type) = materialize_type(
+            &format!("{}Item0", name),
+            &tuple_type_node.items[0],
+            ir,
+            &TypeKindIr::Helper,
+        );
 
         ir.type_aliases.insert(name.to_string(), field_type);
 
@@ -110,7 +115,8 @@ fn build_defined_type_tuple(
     let mut fields = Vec::with_capacity(tuple_type_node.items.len());
 
     for (i, item) in tuple_type_node.items.iter().enumerate() {
-        let (label, field_type) = map_type_with_label(item);
+        let item_name = format!("{}Item{}", name, i);
+        let (label, field_type) = materialize_type(&item_name, item, ir, &TypeKindIr::Helper);
 
         fields.push(FieldIr {
             name: format!("item_{}", i),
@@ -214,13 +220,17 @@ fn build_enum_variant_payload(
 
         codama_nodes::EnumVariantTypeNode::Tuple(variant) => {
             let variant_name = crate::utils::to_pascal_case(&variant.name);
+            let payload_name = format!("{}{}", enum_name, variant_name);
 
             let tuple = match &variant.tuple {
                 NestedTypeNode::Value(tuple) => tuple,
                 _ => panic!("enum tuple variant payload must be NestedTypeNode::Value"),
             };
 
-            (variant_name, build_tuple_payload_fields(&tuple.items))
+            (
+                variant_name,
+                build_tuple_payload_fields(&payload_name, &tuple.items, ir),
+            )
         },
 
         codama_nodes::EnumVariantTypeNode::Struct(variant) => {
@@ -242,17 +252,27 @@ fn build_enum_variant_payload(
 }
 
 /// For tuple-variant payloads: generate item_0..item_n fields.
-fn build_tuple_payload_fields(items: &[codama_nodes::TypeNode]) -> Vec<FieldIr> {
+fn build_tuple_payload_fields(
+    parent_name: &str,
+    items: &[codama_nodes::TypeNode],
+    ir: &mut SchemaIr,
+) -> Vec<FieldIr> {
     let mut fields = Vec::with_capacity(items.len());
 
     for (j, item) in items.iter().enumerate() {
-        let (label, field_type) = map_type_with_label(item);
+        let item_name = format!("item_{}", j);
+        let item_base_name = format!(
+            "{}{}",
+            parent_name,
+            crate::utils::to_pascal_case(&item_name)
+        );
+        let (label, field_type) = materialize_type(&item_base_name, item, ir, &TypeKindIr::Helper);
 
         fields.push(FieldIr {
-            name: format!("item_{}", j),
+            name: item_name,
             tag: (j + 1) as u32,
             label,
-            field_type,
+            field_type: ir.resolve_field_type(field_type),
         });
     }
 

--- a/crates/proc-macro/src/intermediate_representation/build_defined_types.rs
+++ b/crates/proc-macro/src/intermediate_representation/build_defined_types.rs
@@ -1,8 +1,8 @@
 use codama_nodes::{DefinedTypeNode, NestedTypeNode, TypeNode};
 
 use crate::intermediate_representation::{
-    helpers::{build_fields_ir, map_type_with_label, materialize_type},
-    FieldIr, OneofIr, OneofVariantIr, SchemaIr, TypeIr, TypeKindIr,
+    helpers::{build_fields_ir, materialize_type},
+    FieldIr, OneofIr, OneofVariantIr, SchemaIr, TypeAliasIr, TypeIr, TypeKindIr,
 };
 
 /// Converts Codama `defined_types` into our internal Intermediate Representation (IR).
@@ -17,8 +17,9 @@ pub fn build_defined_types(defined_types: &[DefinedTypeNode], ir: &mut SchemaIr)
         match &defined_type.r#type {
             TypeNode::Tuple(tuple_type) => build_defined_type_tuple(&name, tuple_type, ir),
             other if !matches!(other, TypeNode::Struct(_) | TypeNode::Enum(_)) => {
-                let (_, field_type) = map_type_with_label(other);
-                ir.type_aliases.insert(name, field_type);
+                let (label, field_type) = materialize_type(&name, other, ir, &TypeKindIr::Helper);
+                ir.type_aliases
+                    .insert(name, TypeAliasIr { label, field_type });
             },
             _ => {},
         }
@@ -100,14 +101,15 @@ fn build_defined_type_tuple(
 ) {
     // Single-item tuples are inlined as their inner type (e.g. optionBool → bool).
     if tuple_type_node.items.len() == 1 {
-        let (_label, field_type) = materialize_type(
+        let (label, field_type) = materialize_type(
             &format!("{}Item0", name),
             &tuple_type_node.items[0],
             ir,
             &TypeKindIr::Helper,
         );
 
-        ir.type_aliases.insert(name.to_string(), field_type);
+        ir.type_aliases
+            .insert(name.to_string(), TypeAliasIr { label, field_type });
 
         return;
     }
@@ -272,7 +274,7 @@ fn build_tuple_payload_fields(
             name: item_name,
             tag: (j + 1) as u32,
             label,
-            field_type: ir.resolve_field_type(field_type),
+            field_type,
         });
     }
 

--- a/crates/proc-macro/src/intermediate_representation/build_defined_types.rs
+++ b/crates/proc-macro/src/intermediate_representation/build_defined_types.rs
@@ -2,36 +2,73 @@ use codama_nodes::{DefinedTypeNode, NestedTypeNode, TypeNode};
 
 use crate::intermediate_representation::{
     helpers::{build_fields_ir, materialize_type},
-    FieldIr, OneofIr, OneofVariantIr, SchemaIr, TypeAliasIr, TypeIr, TypeKindIr,
+    FieldIr, OneofIr, OneofVariantIr, SchemaIr, TypeIr, TypeKindIr,
 };
 
 /// Converts Codama `defined_types` into our internal Intermediate Representation (IR).
 ///
 /// In the IDL, `defined_types` are user-defined structs, enums, or tuples.
 pub fn build_defined_types(defined_types: &[DefinedTypeNode], ir: &mut SchemaIr) {
-    // First pass: register all type aliases (tuples and scalar aliases) so that
-    // forward references from struct fields resolve correctly regardless of order.
+    // Register every raw defined type before materializing anything. Fixed
+    // options and aliases can then resolve forward references safely.
+    for defined_type in defined_types {
+        let name = crate::utils::to_pascal_case(&defined_type.name);
+
+        ir.register_defined_type(name, defined_type.r#type.clone());
+    }
+
+    // Concrete user-defined types must keep their names even when generated
+    // helpers are emitted before the type itself.
+    ir.reserve_type_names(defined_types.iter().filter_map(|defined_type| {
+        let is_concrete = match &defined_type.r#type {
+            TypeNode::Struct(_) | TypeNode::Enum(_) => true,
+            TypeNode::Tuple(tuple) => tuple.items.len() != 1,
+            _ => false,
+        };
+
+        is_concrete.then(|| crate::utils::to_pascal_case(&defined_type.name))
+    }));
+
+    // Register aliases before materializing them. `materialize_type_alias`
+    // resolves nested aliases recursively, including forward references.
+    let mut alias_names = Vec::new();
+
     for defined_type in defined_types {
         let name = crate::utils::to_pascal_case(&defined_type.name);
 
         match &defined_type.r#type {
-            TypeNode::Tuple(tuple_type) => build_defined_type_tuple(&name, tuple_type, ir),
+            TypeNode::Tuple(tuple_type) if tuple_type.items.len() == 1 => {
+                ir.register_type_alias(
+                    name.clone(),
+                    tuple_type.items[0].clone(),
+                    format!("{name}Item0"),
+                );
+                alias_names.push(name);
+            },
+            TypeNode::Tuple(_) => {},
             other if !matches!(other, TypeNode::Struct(_) | TypeNode::Enum(_)) => {
-                let (label, field_type) = materialize_type(&name, other, ir, &TypeKindIr::Helper);
-                ir.type_aliases
-                    .insert(name, TypeAliasIr { label, field_type });
+                ir.register_type_alias(name.clone(), other.clone(), name.clone());
+                alias_names.push(name);
             },
             _ => {},
         }
     }
 
-    // Second pass: process structs and enums, which may reference the aliases above.
+    for name in alias_names {
+        ir.materialize_type_alias(&name);
+    }
+
+    // Process concrete types after aliases. They may reference any registered
+    // alias regardless of declaration order.
     for defined_type in defined_types {
         let name = crate::utils::to_pascal_case(&defined_type.name);
 
         match &defined_type.r#type {
             TypeNode::Struct(struct_type) => build_defined_type_struct(&name, struct_type, ir),
             TypeNode::Enum(enum_type) => build_defined_type_enum(&name, enum_type, ir),
+            TypeNode::Tuple(tuple_type) if tuple_type.items.len() != 1 => {
+                build_defined_type_tuple(&name, tuple_type, ir)
+            },
             _ => {},
         }
     }
@@ -99,20 +136,7 @@ fn build_defined_type_tuple(
     tuple_type_node: &codama_nodes::TupleTypeNode,
     ir: &mut SchemaIr,
 ) {
-    // Single-item tuples are inlined as their inner type (e.g. optionBool → bool).
-    if tuple_type_node.items.len() == 1 {
-        let (label, field_type) = materialize_type(
-            &format!("{}Item0", name),
-            &tuple_type_node.items[0],
-            ir,
-            &TypeKindIr::Helper,
-        );
-
-        ir.type_aliases
-            .insert(name.to_string(), TypeAliasIr { label, field_type });
-
-        return;
-    }
+    debug_assert_ne!(tuple_type_node.items.len(), 1);
 
     let mut fields = Vec::with_capacity(tuple_type_node.items.len());
 
@@ -178,10 +202,8 @@ fn build_defined_type_enum(name: &str, en: &codama_nodes::EnumTypeNode, ir: &mut
 
         let (variant_name, payload_fields) = build_enum_variant_payload(&enum_name, variant, ir);
 
-        let payload_name = format!("{}{}", enum_name, variant_name);
-
-        ir.types.push(TypeIr {
-            name: payload_name.clone(),
+        let payload_name = ir.push_unique_type(TypeIr {
+            name: format!("{}{}", enum_name, variant_name),
             fields: payload_fields,
             kind: TypeKindIr::Helper,
         });

--- a/crates/proc-macro/src/intermediate_representation/build_instructions_schema.rs
+++ b/crates/proc-macro/src/intermediate_representation/build_instructions_schema.rs
@@ -1,8 +1,8 @@
 use codama_nodes::InstructionNode;
 
 use crate::intermediate_representation::{
-    helpers::build_fields_ir, FieldIr, FieldTypeIr, LabelIr, OneofIr, OneofVariantIr, ScalarIr,
-    SchemaIr, TypeIr, TypeKindIr,
+    helpers::build_fields_ir, FieldIr, FieldTypeIr, LabelIr, OneofIr, OneofVariantIr,
+    OptionEncodingIr, ScalarIr, SchemaIr, TypeIr, TypeKindIr,
 };
 
 ///
@@ -127,7 +127,7 @@ fn build_instruction_messages(ix: &InstructionNode, ir: &mut SchemaIr) {
             name: crate::utils::to_snake_case(&acct.name),
             tag: (i + 1) as u32,
             label: if acct.is_optional {
-                LabelIr::Optional
+                LabelIr::Optional(OptionEncodingIr::default())
             } else {
                 LabelIr::Singular
             },

--- a/crates/proc-macro/src/intermediate_representation/build_schema_ir.rs
+++ b/crates/proc-macro/src/intermediate_representation/build_schema_ir.rs
@@ -6,11 +6,7 @@ use crate::intermediate_representation::SchemaIr;
 ///
 /// Why use IR? So we can unify the parsing. Then we have one source of truth for both the .proto renderer and Rust code.
 pub fn build_schema_ir(idl: &RootNode, events: &[EventNode]) -> SchemaIr {
-    let mut ir = SchemaIr {
-        types: Vec::new(),
-        oneofs: Vec::new(),
-        type_aliases: std::collections::HashMap::new(),
-    };
+    let mut ir = SchemaIr::default();
 
     crate::intermediate_representation::build_defined_types(&idl.program.defined_types, &mut ir);
 

--- a/crates/proc-macro/src/intermediate_representation/build_schema_ir.rs
+++ b/crates/proc-macro/src/intermediate_representation/build_schema_ir.rs
@@ -8,6 +8,8 @@ use crate::intermediate_representation::SchemaIr;
 pub fn build_schema_ir(idl: &RootNode, events: &[EventNode]) -> SchemaIr {
     let mut ir = SchemaIr::default();
 
+    reserve_direct_message_names(idl, events, &mut ir);
+
     crate::intermediate_representation::build_defined_types(&idl.program.defined_types, &mut ir);
 
     crate::intermediate_representation::build_accounts(&idl.program.accounts, &mut ir);
@@ -22,4 +24,67 @@ pub fn build_schema_ir(idl: &RootNode, events: &[EventNode]) -> SchemaIr {
     }
 
     ir
+}
+
+/// Reserve names that are emitted directly by the account, instruction, and
+/// event builders before inline helpers are materialized. Helpers are the only
+/// generated messages whose names can be changed without changing parser APIs;
+/// direct messages must keep their established names.
+fn reserve_direct_message_names(idl: &RootNode, events: &[EventNode], ir: &mut SchemaIr) {
+    let program_name = crate::utils::to_pascal_case(&idl.program.name);
+    let mut names = vec!["PublicKey".to_string()];
+
+    for account in &idl.program.accounts {
+        names.push(crate::utils::to_pascal_case(&account.name));
+    }
+
+    if !idl.program.accounts.is_empty() {
+        let default_wrapper = format!("{program_name}Account");
+        let wrapper_name = if idl
+            .program
+            .accounts
+            .iter()
+            .any(|account| crate::utils::to_pascal_case(&account.name) == default_wrapper)
+        {
+            format!("{program_name}AccountOutput")
+        } else {
+            default_wrapper
+        };
+
+        names.push(wrapper_name);
+    }
+
+    for instruction in &idl.program.instructions {
+        let name = crate::utils::to_pascal_case(&instruction.name);
+
+        names.extend([
+            name.clone(),
+            format!("{name}Accounts"),
+            format!("{name}Args"),
+        ]);
+    }
+
+    if !idl.program.instructions.is_empty() {
+        names.push("Instructions".to_string());
+    }
+
+    if cfg!(feature = "program-events") && !events.is_empty() {
+        for event in events {
+            let name = crate::utils::to_pascal_case(&event.name);
+
+            names.extend([
+                name.clone(),
+                format!("{name}Accounts"),
+                format!("{name}Args"),
+            ]);
+        }
+
+        names.push("ProgramEvents".to_string());
+
+        if !idl.program.instructions.is_empty() {
+            names.push("ProgramEventOutput".to_string());
+        }
+    }
+
+    ir.reserve_type_names(names);
 }

--- a/crates/proc-macro/src/intermediate_representation/helpers.rs
+++ b/crates/proc-macro/src/intermediate_representation/helpers.rs
@@ -124,19 +124,14 @@ pub fn materialize_type(
 
     match type_node {
         T::Struct(struct_type) => {
-            materialize_struct_message(base_name, struct_type, ir, kind.clone());
-            (
-                LabelIr::Singular,
-                FieldTypeIr::Message(base_name.to_string()),
-            )
+            let struct_name = materialize_struct_message(base_name, struct_type, ir, kind.clone());
+            (LabelIr::Singular, FieldTypeIr::Message(struct_name))
         },
 
-        // Keep the existing tuple representation: tuple fields are optional
-        // message fields in the generated Rust/protobuf model.
         T::Tuple(tuple) => {
             let tuple_name = format!("{}Tuple", base_name);
-            materialize_tuple_message(&tuple_name, tuple, ir, kind);
-            (LabelIr::Optional, FieldTypeIr::Message(tuple_name))
+            let tuple_name = materialize_tuple_message(&tuple_name, tuple, ir, kind);
+            (LabelIr::Singular, FieldTypeIr::Message(tuple_name))
         },
 
         T::Option(option) => {
@@ -151,9 +146,8 @@ pub fn materialize_type(
                 return (LabelIr::Optional, ir.resolve_field_type(inner_type));
             }
 
-            let wrapper_name = format!("{}Option", base_name);
-            ir.push_unique_type(TypeIr {
-                name: wrapper_name.clone(),
+            let wrapper_name = ir.push_unique_type(TypeIr {
+                name: format!("{}Option", base_name),
                 fields: vec![FieldIr {
                     name: "value".to_string(),
                     tag: 1,
@@ -186,9 +180,8 @@ pub fn materialize_type(
                 return (outer_label, ir.resolve_field_type(inner_type));
             }
 
-            let wrapper_name = format!("{}Inner", base_name);
-            ir.push_unique_type(TypeIr {
-                name: wrapper_name.clone(),
+            let wrapper_name = ir.push_unique_type(TypeIr {
+                name: format!("{}Inner", base_name),
                 fields: vec![FieldIr {
                     name: "items".to_string(),
                     tag: 1,
@@ -211,14 +204,14 @@ fn materialize_struct_message(
     struct_type: &codama_nodes::StructTypeNode,
     ir: &mut SchemaIr,
     type_kind: TypeKindIr,
-) {
+) -> String {
     let fields = build_fields_ir(struct_msg_name, &struct_type.fields, ir, type_kind.clone());
 
     ir.push_unique_type(TypeIr {
         name: struct_msg_name.to_string(),
         fields,
         kind: type_kind,
-    });
+    })
 }
 
 ///
@@ -246,7 +239,7 @@ fn materialize_tuple_message(
     tuple: &codama_nodes::TupleTypeNode,
     ir: &mut SchemaIr,
     kind: &TypeKindIr,
-) {
+) -> String {
     let mut fields = Vec::new();
 
     for (i, item) in tuple.items.iter().enumerate() {
@@ -272,7 +265,7 @@ fn materialize_tuple_message(
         name: tuple_msg_name.to_string(),
         fields,
         kind: kind.clone(),
-    });
+    })
 }
 
 pub fn map_type_with_label(type_node: &codama_nodes::TypeNode) -> (LabelIr, FieldTypeIr) {

--- a/crates/proc-macro/src/intermediate_representation/helpers.rs
+++ b/crates/proc-macro/src/intermediate_representation/helpers.rs
@@ -31,7 +31,8 @@ impl FieldLikeNode for codama_nodes::InstructionArgumentNode {
 }
 
 ///
-/// Build IR fields from any field-like nodes, handling inline tuple definitions by materializing new messages for them.
+/// Build IR fields from any field-like nodes, handling inline tuple and struct
+/// definitions by materializing new messages for them.
 ///
 /// E.g. for a struct like:
 ///
@@ -107,6 +108,61 @@ pub fn build_fields_ir(
                 });
             },
 
+            // Inline struct => materialize a helper message and reference it directly.
+            // Codama permits structs to appear inline, while the protobuf IR needs
+            // every message-valued field to have a named message type.
+            codama_nodes::TypeNode::Struct(struct_type) => {
+                let struct_msg_name = format!(
+                    "{}{}",
+                    parent_name,
+                    crate::utils::to_pascal_case(&field_name)
+                );
+
+                materialize_struct_message(
+                    &struct_msg_name,
+                    struct_type,
+                    ir,
+                    tuple_msg_kind.clone(),
+                );
+
+                out.push(FieldIr {
+                    name: field_name,
+                    tag,
+                    label: LabelIr::Singular,
+                    field_type: FieldTypeIr::Message(struct_msg_name),
+                });
+            },
+
+            // Inline structs can also be nested inside Codama's fixed option
+            // wrapper, as in `Option<MetadataName>`.
+            codama_nodes::TypeNode::Option(option)
+                if matches!(&*option.item, codama_nodes::TypeNode::Struct(_)) =>
+            {
+                let codama_nodes::TypeNode::Struct(struct_type) = &*option.item else {
+                    unreachable!();
+                };
+
+                let struct_msg_name = format!(
+                    "{}{}",
+                    parent_name,
+                    crate::utils::to_pascal_case(&field_name)
+                );
+
+                materialize_struct_message(
+                    &struct_msg_name,
+                    struct_type,
+                    ir,
+                    tuple_msg_kind.clone(),
+                );
+
+                out.push(FieldIr {
+                    name: field_name,
+                    tag,
+                    label: LabelIr::Optional,
+                    field_type: FieldTypeIr::Message(struct_msg_name),
+                });
+            },
+
             //
             // Nested array (e.g. Vec<Vec<Route>>) => materialize a wrapper message
             // for the inner array since LabelIr can only represent one level of Vec.
@@ -169,6 +225,22 @@ pub fn build_fields_ir(
     }
 
     out
+}
+
+/// Materialize an inline Codama struct as a named helper message.
+fn materialize_struct_message(
+    struct_msg_name: &str,
+    struct_type: &codama_nodes::StructTypeNode,
+    ir: &mut SchemaIr,
+    type_kind: TypeKindIr,
+) {
+    let fields = build_fields_ir(struct_msg_name, &struct_type.fields, ir, type_kind.clone());
+
+    ir.push_unique_type(TypeIr {
+        name: struct_msg_name.to_string(),
+        fields,
+        kind: type_kind,
+    });
 }
 
 ///

--- a/crates/proc-macro/src/intermediate_representation/helpers.rs
+++ b/crates/proc-macro/src/intermediate_representation/helpers.rs
@@ -100,7 +100,7 @@ pub fn build_fields_ir(
             name: field_name,
             tag,
             label,
-            field_type: ir.resolve_field_type(field_type),
+            field_type,
         });
     }
 
@@ -143,7 +143,7 @@ pub fn materialize_type(
             let (inner_label, inner_type) = materialize_type(&inner_base, &option.item, ir, kind);
 
             if matches!(inner_label, LabelIr::Singular) {
-                return (LabelIr::Optional, ir.resolve_field_type(inner_type));
+                return (LabelIr::Optional, inner_type);
             }
 
             let wrapper_name = ir.push_unique_type(TypeIr {
@@ -152,7 +152,7 @@ pub fn materialize_type(
                     name: "value".to_string(),
                     tag: 1,
                     label: inner_label,
-                    field_type: ir.resolve_field_type(inner_type),
+                    field_type: inner_type,
                 }],
                 kind: kind.clone(),
             });
@@ -177,7 +177,7 @@ pub fn materialize_type(
             let (inner_label, inner_type) = materialize_type(&inner_base, &array.item, ir, kind);
 
             if matches!(inner_label, LabelIr::Singular) {
-                return (outer_label, ir.resolve_field_type(inner_type));
+                return (outer_label, inner_type);
             }
 
             let wrapper_name = ir.push_unique_type(TypeIr {
@@ -186,7 +186,7 @@ pub fn materialize_type(
                     name: "items".to_string(),
                     tag: 1,
                     label: inner_label,
-                    field_type: ir.resolve_field_type(inner_type),
+                    field_type: inner_type,
                 }],
                 kind: kind.clone(),
             });
@@ -194,7 +194,7 @@ pub fn materialize_type(
             (outer_label, FieldTypeIr::Message(wrapper_name))
         },
 
-        other => (LabelIr::Singular, ir.resolve_field_type(map_type(other))),
+        other => ir.resolve_field(LabelIr::Singular, map_type(other)),
     }
 }
 
@@ -257,7 +257,7 @@ fn materialize_tuple_message(
             name: item_name,
             tag,
             label,
-            field_type: ir.resolve_field_type(field_type),
+            field_type,
         });
     }
 
@@ -268,27 +268,9 @@ fn materialize_tuple_message(
     })
 }
 
-pub fn map_type_with_label(type_node: &codama_nodes::TypeNode) -> (LabelIr, FieldTypeIr) {
-    use codama_nodes::TypeNode as T;
-
-    match type_node {
-        T::Option(option) => (LabelIr::Optional, map_type(&option.item)),
-        T::Array(array) => {
-            let label = match &array.count {
-                codama_nodes::CountNode::Fixed(fixed) => LabelIr::FixedArray(fixed.value),
-                _ => LabelIr::Repeated,
-            };
-
-            (label, map_type(&array.item))
-        },
-        _ => (LabelIr::Singular, map_type(type_node)),
-    }
-}
-
 /// Map a single Codama type node to its IR scalar/message type.
 ///
-/// Does NOT handle wrappers like Option/Array (use `map_type_with_label` for that)
-/// or Tuple (handled by `materialize_tuple_message`).
+/// Wrappers like Option/Array and Tuple are handled by `materialize_type`.
 fn map_type(t: &codama_nodes::TypeNode) -> FieldTypeIr {
     use codama_nodes::{NumberFormat as NF, TypeNode as T};
 

--- a/crates/proc-macro/src/intermediate_representation/helpers.rs
+++ b/crates/proc-macro/src/intermediate_representation/helpers.rs
@@ -89,142 +89,120 @@ pub fn build_fields_ir(
             }
         };
 
-        match field.r#type() {
-            // Inline tuple => materialize a new message and reference it as Optional
-            codama_nodes::TypeNode::Tuple(tuple) => {
-                let tuple_msg_name = format!(
-                    "{}{}Tuple",
-                    parent_name,
-                    crate::utils::to_pascal_case(&field_name)
-                );
+        let base_name = format!(
+            "{}{}",
+            parent_name,
+            crate::utils::to_pascal_case(&field_name)
+        );
+        let (label, field_type) = materialize_type(&base_name, field.r#type(), ir, &tuple_msg_kind);
 
-                materialize_tuple_message(&tuple_msg_name, tuple, ir, &tuple_msg_kind);
-
-                out.push(FieldIr {
-                    name: field_name,
-                    tag,
-                    label: LabelIr::Optional,
-                    field_type: FieldTypeIr::Message(tuple_msg_name),
-                });
-            },
-
-            // Inline struct => materialize a helper message and reference it directly.
-            // Codama permits structs to appear inline, while the protobuf IR needs
-            // every message-valued field to have a named message type.
-            codama_nodes::TypeNode::Struct(struct_type) => {
-                let struct_msg_name = format!(
-                    "{}{}",
-                    parent_name,
-                    crate::utils::to_pascal_case(&field_name)
-                );
-
-                materialize_struct_message(
-                    &struct_msg_name,
-                    struct_type,
-                    ir,
-                    tuple_msg_kind.clone(),
-                );
-
-                out.push(FieldIr {
-                    name: field_name,
-                    tag,
-                    label: LabelIr::Singular,
-                    field_type: FieldTypeIr::Message(struct_msg_name),
-                });
-            },
-
-            // Inline structs can also be nested inside Codama's fixed option
-            // wrapper, as in `Option<MetadataName>`.
-            codama_nodes::TypeNode::Option(option)
-                if matches!(&*option.item, codama_nodes::TypeNode::Struct(_)) =>
-            {
-                let codama_nodes::TypeNode::Struct(struct_type) = &*option.item else {
-                    unreachable!();
-                };
-
-                let struct_msg_name = format!(
-                    "{}{}",
-                    parent_name,
-                    crate::utils::to_pascal_case(&field_name)
-                );
-
-                materialize_struct_message(
-                    &struct_msg_name,
-                    struct_type,
-                    ir,
-                    tuple_msg_kind.clone(),
-                );
-
-                out.push(FieldIr {
-                    name: field_name,
-                    tag,
-                    label: LabelIr::Optional,
-                    field_type: FieldTypeIr::Message(struct_msg_name),
-                });
-            },
-
-            //
-            // Nested array (e.g. Vec<Vec<Route>>) => materialize a wrapper message
-            // for the inner array since LabelIr can only represent one level of Vec.
-            //
-            // E.g. `routes: Vec<Vec<Route>>` becomes:
-            //
-            // ```protobuf
-            //   message RoutesInner { repeated Route items = 1; }
-            //   repeated RoutesInner routes = N;
-            // ```
-            //
-            codama_nodes::TypeNode::Array(outer_array)
-                if matches!(&*outer_array.item, codama_nodes::TypeNode::Array(_)) =>
-            {
-                let wrapper_name = format!(
-                    "{}{}Inner",
-                    parent_name,
-                    crate::utils::to_pascal_case(&field_name)
-                );
-
-                let (inner_label, inner_type) = map_type_with_label(&outer_array.item);
-                let inner_type = ir.resolve_field_type(inner_type);
-
-                ir.push_unique_type(TypeIr {
-                    name: wrapper_name.clone(),
-                    fields: vec![FieldIr {
-                        name: "items".to_string(),
-                        tag: 1,
-                        label: inner_label,
-                        field_type: inner_type,
-                    }],
-                    kind: tuple_msg_kind.clone(),
-                });
-
-                let outer_label = match &outer_array.count {
-                    codama_nodes::CountNode::Fixed(fixed) => LabelIr::FixedArray(fixed.value),
-                    _ => LabelIr::Repeated,
-                };
-
-                out.push(FieldIr {
-                    name: field_name,
-                    tag,
-                    label: outer_label,
-                    field_type: FieldTypeIr::Message(wrapper_name),
-                });
-            },
-
-            other => {
-                let (label, field_type) = map_type_with_label(other);
-                let field_type = ir.resolve_field_type(field_type);
-
-                out.push(FieldIr {
-                    name: field_name,
-                    tag,
-                    label,
-                    field_type,
-                });
-            },
-        }
+        out.push(FieldIr {
+            name: field_name,
+            tag,
+            label,
+            field_type: ir.resolve_field_type(field_type),
+        });
     }
 
     out
+}
+
+/// Materialize a Codama type whenever its protobuf representation needs a
+/// named message. This is recursive so inline structs continue to work when
+/// they are nested in arrays, tuples, options, or combinations of wrappers.
+///
+/// Direct inline structs and options containing one keep the names emitted by
+/// the original implementation. Additional wrapper messages get suffixes to
+/// avoid reusing a name at a different nesting depth.
+pub fn materialize_type(
+    base_name: &str,
+    type_node: &codama_nodes::TypeNode,
+    ir: &mut SchemaIr,
+    kind: &TypeKindIr,
+) -> (LabelIr, FieldTypeIr) {
+    use codama_nodes::TypeNode as T;
+
+    match type_node {
+        T::Struct(struct_type) => {
+            materialize_struct_message(base_name, struct_type, ir, kind.clone());
+            (
+                LabelIr::Singular,
+                FieldTypeIr::Message(base_name.to_string()),
+            )
+        },
+
+        // Keep the existing tuple representation: tuple fields are optional
+        // message fields in the generated Rust/protobuf model.
+        T::Tuple(tuple) => {
+            let tuple_name = format!("{}Tuple", base_name);
+            materialize_tuple_message(&tuple_name, tuple, ir, kind);
+            (LabelIr::Optional, FieldTypeIr::Message(tuple_name))
+        },
+
+        T::Option(option) => {
+            let inner_base = if matches!(&*option.item, T::Struct(_)) {
+                base_name.to_string()
+            } else {
+                format!("{}Value", base_name)
+            };
+            let (inner_label, inner_type) = materialize_type(&inner_base, &option.item, ir, kind);
+
+            if matches!(inner_label, LabelIr::Singular) {
+                return (LabelIr::Optional, ir.resolve_field_type(inner_type));
+            }
+
+            let wrapper_name = format!("{}Option", base_name);
+            ir.push_unique_type(TypeIr {
+                name: wrapper_name.clone(),
+                fields: vec![FieldIr {
+                    name: "value".to_string(),
+                    tag: 1,
+                    label: inner_label,
+                    field_type: ir.resolve_field_type(inner_type),
+                }],
+                kind: kind.clone(),
+            });
+
+            (LabelIr::Optional, FieldTypeIr::Message(wrapper_name))
+        },
+
+        T::Array(array) => {
+            let outer_label = match &array.count {
+                codama_nodes::CountNode::Fixed(fixed) => LabelIr::FixedArray(fixed.value),
+                _ => LabelIr::Repeated,
+            };
+
+            // Array<struct> can use the field helper directly. More complex
+            // items get a distinct name so nested arrays do not collide with
+            // their enclosing wrapper.
+            let inner_base = if matches!(&*array.item, T::Struct(_)) {
+                base_name.to_string()
+            } else {
+                format!("{}Item", base_name)
+            };
+            let (inner_label, inner_type) = materialize_type(&inner_base, &array.item, ir, kind);
+
+            if matches!(inner_label, LabelIr::Singular) {
+                return (outer_label, ir.resolve_field_type(inner_type));
+            }
+
+            let wrapper_name = format!("{}Inner", base_name);
+            ir.push_unique_type(TypeIr {
+                name: wrapper_name.clone(),
+                fields: vec![FieldIr {
+                    name: "items".to_string(),
+                    tag: 1,
+                    label: inner_label,
+                    field_type: ir.resolve_field_type(inner_type),
+                }],
+                kind: kind.clone(),
+            });
+
+            (outer_label, FieldTypeIr::Message(wrapper_name))
+        },
+
+        other => (LabelIr::Singular, ir.resolve_field_type(map_type(other))),
+    }
 }
 
 /// Materialize an inline Codama struct as a named helper message.
@@ -275,35 +253,19 @@ fn materialize_tuple_message(
         let item_name = format!("item_{}", i);
         let tag = (i + 1) as u32;
 
-        match item {
-            // Nested tuple => recurse to materialize it first, then reference the message
-            codama_nodes::TypeNode::Tuple(inner_tuple) => {
-                let inner_msg_name = format!(
-                    "{}{}Tuple",
-                    tuple_msg_name,
-                    crate::utils::to_pascal_case(&item_name)
-                );
+        let item_base_name = format!(
+            "{}{}",
+            tuple_msg_name,
+            crate::utils::to_pascal_case(&item_name)
+        );
+        let (label, field_type) = materialize_type(&item_base_name, item, ir, kind);
 
-                materialize_tuple_message(&inner_msg_name, inner_tuple, ir, kind);
-
-                fields.push(FieldIr {
-                    name: item_name,
-                    tag,
-                    label: LabelIr::Optional,
-                    field_type: FieldTypeIr::Message(inner_msg_name),
-                });
-            },
-
-            other => {
-                let (label, field_type) = map_type_with_label(other);
-                fields.push(FieldIr {
-                    name: item_name,
-                    tag,
-                    label,
-                    field_type,
-                });
-            },
-        }
+        fields.push(FieldIr {
+            name: item_name,
+            tag,
+            label,
+            field_type: ir.resolve_field_type(field_type),
+        });
     }
 
     ir.push_unique_type(TypeIr {

--- a/crates/proc-macro/src/intermediate_representation/helpers.rs
+++ b/crates/proc-macro/src/intermediate_representation/helpers.rs
@@ -1,5 +1,6 @@
 use crate::intermediate_representation::{
-    FieldIr, FieldTypeIr, LabelIr, ScalarIr, SchemaIr, TypeIr, TypeKindIr,
+    FieldIr, FieldTypeIr, LabelIr, OptionEncodingIr, OptionPrefixIr, ScalarIr, SchemaIr, TypeIr,
+    TypeKindIr,
 };
 
 /// Common interface for field-like nodes from Codama (both struct fields and instruction arguments).
@@ -135,6 +136,7 @@ pub fn materialize_type(
         },
 
         T::Option(option) => {
+            let option_encoding = option_encoding(option, ir, base_name);
             let inner_base = if matches!(&*option.item, T::Struct(_)) {
                 base_name.to_string()
             } else {
@@ -143,7 +145,7 @@ pub fn materialize_type(
             let (inner_label, inner_type) = materialize_type(&inner_base, &option.item, ir, kind);
 
             if matches!(inner_label, LabelIr::Singular) {
-                return (LabelIr::Optional, inner_type);
+                return (LabelIr::Optional(option_encoding), inner_type);
             }
 
             let wrapper_name = ir.push_unique_type(TypeIr {
@@ -157,7 +159,10 @@ pub fn materialize_type(
                 kind: kind.clone(),
             });
 
-            (LabelIr::Optional, FieldTypeIr::Message(wrapper_name))
+            (
+                LabelIr::Optional(option_encoding),
+                FieldTypeIr::Message(wrapper_name),
+            )
         },
 
         T::Array(array) => {
@@ -194,7 +199,75 @@ pub fn materialize_type(
             (outer_label, FieldTypeIr::Message(wrapper_name))
         },
 
+        T::Link(link) => {
+            let name = crate::utils::to_pascal_case(&link.name);
+
+            if ir.has_type_alias_definition(&name) {
+                ir.materialize_type_alias(&name)
+            } else {
+                ir.resolve_field(LabelIr::Singular, FieldTypeIr::Message(name))
+            }
+        },
+
         other => ir.resolve_field(LabelIr::Singular, map_type(other)),
+    }
+}
+
+fn option_encoding(
+    option: &codama_nodes::OptionTypeNode,
+    ir: &SchemaIr,
+    base_name: &str,
+) -> OptionEncodingIr {
+    use codama_nodes::{Endian, NestedTypeNodeTrait, NumberFormat};
+
+    let prefix_type = option.prefix.get_nested_type_node();
+    let prefix = match prefix_type.format {
+        NumberFormat::ShortU16 => OptionPrefixIr::ShortU16,
+        NumberFormat::U8 | NumberFormat::I8 => OptionPrefixIr::FixedWidth {
+            byte_len: 1,
+            one_value: 1,
+            big_endian: false,
+        },
+        NumberFormat::U16 | NumberFormat::I16 => OptionPrefixIr::FixedWidth {
+            byte_len: 2,
+            one_value: 1,
+            big_endian: prefix_type.endian == Endian::Big,
+        },
+        NumberFormat::U32 | NumberFormat::I32 => OptionPrefixIr::FixedWidth {
+            byte_len: 4,
+            one_value: 1,
+            big_endian: prefix_type.endian == Endian::Big,
+        },
+        NumberFormat::U64 | NumberFormat::I64 => OptionPrefixIr::FixedWidth {
+            byte_len: 8,
+            one_value: 1,
+            big_endian: prefix_type.endian == Endian::Big,
+        },
+        NumberFormat::U128 | NumberFormat::I128 => OptionPrefixIr::FixedWidth {
+            byte_len: 16,
+            one_value: 1,
+            big_endian: prefix_type.endian == Endian::Big,
+        },
+        NumberFormat::F32 => OptionPrefixIr::FixedWidth {
+            byte_len: 4,
+            one_value: 1.0f32.to_bits() as u128,
+            big_endian: prefix_type.endian == Endian::Big,
+        },
+        NumberFormat::F64 => OptionPrefixIr::FixedWidth {
+            byte_len: 8,
+            one_value: 1.0f64.to_bits() as u128,
+            big_endian: prefix_type.endian == Endian::Big,
+        },
+    };
+
+    let none_padding = option.fixed.then(|| {
+        ir.fixed_size_of_type(&option.item)
+            .unwrap_or_else(|| panic!("fixed option `{base_name}` has a variable-size item"))
+    });
+
+    OptionEncodingIr {
+        prefix,
+        none_padding,
     }
 }
 

--- a/crates/proc-macro/src/intermediate_representation/schema_ir.rs
+++ b/crates/proc-macro/src/intermediate_representation/schema_ir.rs
@@ -125,17 +125,26 @@ pub struct OneofVariantIr {
 }
 
 impl SchemaIr {
-    pub fn push_unique_type(&mut self, msg: TypeIr) {
-        if let Some(existing) = self.types.iter().find(|existing| existing.name == msg.name) {
-            assert_eq!(
-                existing, &msg,
-                "conflicting IR type definitions for `{}`",
-                msg.name
-            );
-            return;
-        }
+    /// Insert a generated helper type, allocating a numeric suffix when its
+    /// requested name is already used by a different type.
+    pub fn push_unique_type(&mut self, mut msg: TypeIr) -> String {
+        let base_name = msg.name.clone();
+        let mut suffix = 2;
 
-        self.types.push(msg);
+        loop {
+            if let Some(existing) = self.types.iter().find(|existing| existing.name == msg.name) {
+                if existing == &msg {
+                    return msg.name;
+                }
+            } else if !self.type_aliases.contains_key(&msg.name) {
+                let name = msg.name.clone();
+                self.types.push(msg);
+                return name;
+            }
+
+            msg.name = format!("{base_name}{suffix}");
+            suffix += 1;
+        }
     }
 
     /// If `ft` is a `Message` reference to a type alias, return the aliased
@@ -205,17 +214,21 @@ mod tests {
     #[test]
     fn identical_type_definitions_are_deduplicated() {
         let mut ir = schema();
-        ir.push_unique_type(message("Shared", "value"));
-        ir.push_unique_type(message("Shared", "value"));
+        assert_eq!(ir.push_unique_type(message("Shared", "value")), "Shared");
+        assert_eq!(ir.push_unique_type(message("Shared", "value")), "Shared");
 
         assert_eq!(ir.types.len(), 1);
     }
 
     #[test]
-    #[should_panic(expected = "conflicting IR type definitions for `Shared`")]
-    fn conflicting_type_definitions_are_rejected() {
+    fn conflicting_type_definitions_get_unique_names() {
         let mut ir = schema();
-        ir.push_unique_type(message("Shared", "value"));
-        ir.push_unique_type(message("Shared", "other_value"));
+        assert_eq!(ir.push_unique_type(message("Shared", "value")), "Shared");
+        assert_eq!(
+            ir.push_unique_type(message("Shared", "other_value")),
+            "Shared2"
+        );
+
+        assert_eq!(ir.types.len(), 2);
     }
 }

--- a/crates/proc-macro/src/intermediate_representation/schema_ir.rs
+++ b/crates/proc-macro/src/intermediate_representation/schema_ir.rs
@@ -1,4 +1,8 @@
-#[derive(Debug, Clone)]
+use std::collections::{HashMap, HashSet};
+
+use codama_nodes::{NestedTypeNodeTrait, NumberFormat, TypeNode};
+
+#[derive(Debug, Clone, Default)]
 pub struct SchemaIr {
     pub types: Vec<TypeIr>,
     pub oneofs: Vec<OneofIr>,
@@ -10,7 +14,20 @@ pub struct SchemaIr {
     /// `bool` field instead of a wrapper struct with `item_0`. Keeping the
     /// label is important for aliases such as `Option<InlineStruct>` and
     /// `Array<Tuple>`.
-    pub type_aliases: std::collections::HashMap<String, TypeAliasIr>,
+    pub type_aliases: HashMap<String, TypeAliasIr>,
+
+    /// Raw aliases are registered before they are materialized so an alias may
+    /// safely refer to another alias declared later in the IDL.
+    type_alias_definitions: HashMap<String, TypeAliasDefinitionIr>,
+    defined_type_nodes: HashMap<String, TypeNode>,
+    reserved_type_names: HashSet<String>,
+    materializing_type_aliases: HashSet<String>,
+}
+
+#[derive(Debug, Clone)]
+struct TypeAliasDefinitionIr {
+    type_node: TypeNode,
+    base_name: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -45,10 +62,55 @@ pub struct TypeAliasIr {
     pub field_type: FieldTypeIr,
 }
 
+/// The on-chain encoding for a Codama option. Rust's native Borsh `Option`
+/// only covers the default u8 prefix with no fixed-size None padding.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct OptionEncodingIr {
+    pub prefix: OptionPrefixIr,
+    /// Fixed Codama options write this many zero bytes after a None prefix.
+    pub none_padding: Option<usize>,
+}
+
+impl OptionEncodingIr {
+    pub fn uses_native_borsh(&self) -> bool {
+        self.prefix.is_default() && self.none_padding.is_none()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OptionPrefixIr {
+    FixedWidth {
+        byte_len: usize,
+        one_value: u128,
+        big_endian: bool,
+    },
+    ShortU16,
+}
+
+impl Default for OptionPrefixIr {
+    fn default() -> Self {
+        Self::FixedWidth {
+            byte_len: 1,
+            one_value: 1,
+            big_endian: false,
+        }
+    }
+}
+
+impl OptionPrefixIr {
+    pub fn is_default(&self) -> bool {
+        matches!(self, Self::FixedWidth {
+            byte_len: 1,
+            one_value: 1,
+            big_endian: false,
+        })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LabelIr {
     Singular,
-    Optional,
+    Optional(OptionEncodingIr),
     Repeated,
     /// Fixed-count array (no length prefix on-chain). The value is the element count.
     /// Rendered as `Vec<T>` / `repeated` in proto for compatibility, but borsh
@@ -134,6 +196,116 @@ pub struct OneofVariantIr {
 }
 
 impl SchemaIr {
+    pub fn register_defined_type(&mut self, name: String, type_node: TypeNode) {
+        self.defined_type_nodes.insert(name, type_node);
+    }
+
+    pub fn reserve_type_names(&mut self, names: impl IntoIterator<Item = String>) {
+        self.reserved_type_names.extend(names);
+    }
+
+    pub fn register_type_alias(&mut self, name: String, type_node: TypeNode, base_name: String) {
+        self.type_alias_definitions
+            .insert(name, TypeAliasDefinitionIr {
+                type_node,
+                base_name,
+            });
+    }
+
+    pub fn has_type_alias_definition(&self, name: &str) -> bool {
+        self.type_alias_definitions.contains_key(name)
+    }
+
+    /// Materialize an alias on demand so aliases can reference aliases declared
+    /// later in an IDL. Nested wrappers remain explicit rather than being
+    /// flattened into an invalid Rust type.
+    pub fn materialize_type_alias(&mut self, name: &str) -> (LabelIr, FieldTypeIr) {
+        if let Some(alias) = self.type_aliases.get(name) {
+            return (alias.label.clone(), alias.field_type.clone());
+        }
+
+        if !self.materializing_type_aliases.insert(name.to_string()) {
+            panic!("cyclic defined type alias `{name}`");
+        }
+
+        let definition = self
+            .type_alias_definitions
+            .get(name)
+            .unwrap_or_else(|| panic!("unknown defined type alias `{name}`"))
+            .clone();
+        let (label, field_type) = crate::intermediate_representation::helpers::materialize_type(
+            &definition.base_name,
+            &definition.type_node,
+            self,
+            &TypeKindIr::Helper,
+        );
+
+        self.materializing_type_aliases.remove(name);
+        self.type_aliases.insert(name.to_string(), TypeAliasIr {
+            label: label.clone(),
+            field_type: field_type.clone(),
+        });
+
+        (label, field_type)
+    }
+
+    /// Returns the exact wire size of a fixed-size Codama type, if known.
+    /// Fixed options need this to consume the same number of bytes for `None`
+    /// as they do for `Some`.
+    pub fn fixed_size_of_type(&self, type_node: &TypeNode) -> Option<usize> {
+        self.fixed_size_of_type_inner(type_node, &mut HashSet::new())
+    }
+
+    fn fixed_size_of_type_inner(
+        &self,
+        type_node: &TypeNode,
+        visiting_links: &mut HashSet<String>,
+    ) -> Option<usize> {
+        use codama_nodes::{CountNode, DefaultValueStrategy, TypeNode as T};
+
+        match type_node {
+            T::Boolean(_) => Some(1),
+            T::PublicKey(_) => Some(32),
+            T::Number(number) => number_wire_size(number.format),
+            T::FixedSize(fixed) => Some(fixed.size),
+            T::Struct(struct_type) => struct_type
+                .fields
+                .iter()
+                .filter(|field| field.default_value_strategy != Some(DefaultValueStrategy::Omitted))
+                .try_fold(0usize, |size, field| {
+                    size.checked_add(self.fixed_size_of_type_inner(&field.r#type, visiting_links)?)
+                }),
+            T::Tuple(tuple) => tuple.items.iter().try_fold(0usize, |size, item| {
+                size.checked_add(self.fixed_size_of_type_inner(item, visiting_links)?)
+            }),
+            T::Array(array) => match &array.count {
+                CountNode::Fixed(count) => self
+                    .fixed_size_of_type_inner(&array.item, visiting_links)?
+                    .checked_mul(count.value),
+                _ => None,
+            },
+            T::Option(option) if option.fixed => {
+                option_prefix_wire_size(option.prefix.get_nested_type_node().format)?
+                    .checked_add(self.fixed_size_of_type_inner(&option.item, visiting_links)?)
+            },
+            T::Link(link) => {
+                let name = crate::utils::to_pascal_case(&link.name);
+
+                if !visiting_links.insert(name.clone()) {
+                    return None;
+                }
+
+                let result = self
+                    .defined_type_nodes
+                    .get(&name)
+                    .and_then(|node| self.fixed_size_of_type_inner(node, visiting_links));
+                visiting_links.remove(&name);
+                result
+            },
+            _ => None,
+        }
+    }
+
     /// Insert a generated helper type, allocating a numeric suffix when its
     /// requested name is already used by a different type.
     pub fn push_unique_type(&mut self, mut msg: TypeIr) -> String {
@@ -141,6 +313,12 @@ impl SchemaIr {
         let mut suffix = 2;
 
         loop {
+            if self.reserved_type_names.contains(&msg.name) {
+                msg.name = format!("{base_name}{suffix}");
+                suffix += 1;
+                continue;
+            }
+
             if let Some(existing) = self.types.iter().find(|existing| existing.name == msg.name) {
                 if existing == &msg {
                     return msg.name;
@@ -222,13 +400,7 @@ impl SchemaIr {
 mod tests {
     use super::*;
 
-    fn schema() -> SchemaIr {
-        SchemaIr {
-            types: Vec::new(),
-            oneofs: Vec::new(),
-            type_aliases: std::collections::HashMap::new(),
-        }
-    }
+    fn schema() -> SchemaIr { SchemaIr::default() }
 
     fn message(name: &str, field_name: &str) -> TypeIr {
         TypeIr {
@@ -262,5 +434,36 @@ mod tests {
         );
 
         assert_eq!(ir.types.len(), 2);
+    }
+
+    #[test]
+    fn reserved_type_names_force_helpers_to_use_a_suffix() {
+        let mut ir = schema();
+        ir.reserve_type_names(["FooOption".to_string()]);
+
+        assert_eq!(
+            ir.push_unique_type(message("FooOption", "value")),
+            "FooOption2"
+        );
+    }
+}
+
+fn number_wire_size(format: NumberFormat) -> Option<usize> {
+    match format {
+        NumberFormat::U8 | NumberFormat::I8 => Some(1),
+        NumberFormat::U16 | NumberFormat::I16 => Some(2),
+        NumberFormat::U32 | NumberFormat::I32 | NumberFormat::F32 => Some(4),
+        NumberFormat::U64 | NumberFormat::I64 | NumberFormat::F64 => Some(8),
+        NumberFormat::U128 | NumberFormat::I128 => Some(16),
+        NumberFormat::ShortU16 => None,
+    }
+}
+
+fn option_prefix_wire_size(format: NumberFormat) -> Option<usize> {
+    match format {
+        // Option presence is encoded as 0 or 1, both of which are a one-byte
+        // short_u16 value even though arbitrary short_u16 values are variable.
+        NumberFormat::ShortU16 => Some(1),
+        other => number_wire_size(other),
     }
 }

--- a/crates/proc-macro/src/intermediate_representation/schema_ir.rs
+++ b/crates/proc-macro/src/intermediate_representation/schema_ir.rs
@@ -19,7 +19,7 @@ pub enum TypeKindIr {
     Helper,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TypeIr {
     pub name: String,
     pub fields: Vec<FieldIr>,
@@ -28,7 +28,7 @@ pub struct TypeIr {
     pub kind: TypeKindIr,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldIr {
     pub name: String,
     pub tag: u32,
@@ -36,7 +36,7 @@ pub struct FieldIr {
     pub field_type: FieldTypeIr,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LabelIr {
     Singular,
     Optional,
@@ -47,13 +47,13 @@ pub enum LabelIr {
     FixedArray(usize),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FieldTypeIr {
     Scalar(ScalarIr),
     Message(String),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScalarIr {
     Bool,
 
@@ -125,10 +125,13 @@ pub struct OneofVariantIr {
 }
 
 impl SchemaIr {
-    pub fn has_type(&self, name: &str) -> bool { self.types.iter().any(|m| m.name == name) }
-
     pub fn push_unique_type(&mut self, msg: TypeIr) {
-        if self.has_type(&msg.name) {
+        if let Some(existing) = self.types.iter().find(|existing| existing.name == msg.name) {
+            assert_eq!(
+                existing, &msg,
+                "conflicting IR type definitions for `{}`",
+                msg.name
+            );
             return;
         }
 
@@ -171,5 +174,48 @@ impl SchemaIr {
             .filter(|t| top_level.contains(t.name.as_str()))
             .map(|t| t.name.clone())
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn schema() -> SchemaIr {
+        SchemaIr {
+            types: Vec::new(),
+            oneofs: Vec::new(),
+            type_aliases: std::collections::HashMap::new(),
+        }
+    }
+
+    fn message(name: &str, field_name: &str) -> TypeIr {
+        TypeIr {
+            name: name.to_string(),
+            fields: vec![FieldIr {
+                name: field_name.to_string(),
+                tag: 1,
+                label: LabelIr::Singular,
+                field_type: FieldTypeIr::Scalar(ScalarIr::U8),
+            }],
+            kind: TypeKindIr::Helper,
+        }
+    }
+
+    #[test]
+    fn identical_type_definitions_are_deduplicated() {
+        let mut ir = schema();
+        ir.push_unique_type(message("Shared", "value"));
+        ir.push_unique_type(message("Shared", "value"));
+
+        assert_eq!(ir.types.len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "conflicting IR type definitions for `Shared`")]
+    fn conflicting_type_definitions_are_rejected() {
+        let mut ir = schema();
+        ir.push_unique_type(message("Shared", "value"));
+        ir.push_unique_type(message("Shared", "other_value"));
     }
 }

--- a/crates/proc-macro/src/intermediate_representation/schema_ir.rs
+++ b/crates/proc-macro/src/intermediate_representation/schema_ir.rs
@@ -396,6 +396,26 @@ impl SchemaIr {
     }
 }
 
+fn number_wire_size(format: NumberFormat) -> Option<usize> {
+    match format {
+        NumberFormat::U8 | NumberFormat::I8 => Some(1),
+        NumberFormat::U16 | NumberFormat::I16 => Some(2),
+        NumberFormat::U32 | NumberFormat::I32 | NumberFormat::F32 => Some(4),
+        NumberFormat::U64 | NumberFormat::I64 | NumberFormat::F64 => Some(8),
+        NumberFormat::U128 | NumberFormat::I128 => Some(16),
+        NumberFormat::ShortU16 => None,
+    }
+}
+
+fn option_prefix_wire_size(format: NumberFormat) -> Option<usize> {
+    match format {
+        // Option presence is encoded as 0 or 1, both of which are a one-byte
+        // short_u16 value even though arbitrary short_u16 values are variable.
+        NumberFormat::ShortU16 => Some(1),
+        other => number_wire_size(other),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -445,25 +465,5 @@ mod tests {
             ir.push_unique_type(message("FooOption", "value")),
             "FooOption2"
         );
-    }
-}
-
-fn number_wire_size(format: NumberFormat) -> Option<usize> {
-    match format {
-        NumberFormat::U8 | NumberFormat::I8 => Some(1),
-        NumberFormat::U16 | NumberFormat::I16 => Some(2),
-        NumberFormat::U32 | NumberFormat::I32 | NumberFormat::F32 => Some(4),
-        NumberFormat::U64 | NumberFormat::I64 | NumberFormat::F64 => Some(8),
-        NumberFormat::U128 | NumberFormat::I128 => Some(16),
-        NumberFormat::ShortU16 => None,
-    }
-}
-
-fn option_prefix_wire_size(format: NumberFormat) -> Option<usize> {
-    match format {
-        // Option presence is encoded as 0 or 1, both of which are a one-byte
-        // short_u16 value even though arbitrary short_u16 values are variable.
-        NumberFormat::ShortU16 => Some(1),
-        other => number_wire_size(other),
     }
 }

--- a/crates/proc-macro/src/intermediate_representation/schema_ir.rs
+++ b/crates/proc-macro/src/intermediate_representation/schema_ir.rs
@@ -3,11 +3,14 @@ pub struct SchemaIr {
     pub types: Vec<TypeIr>,
     pub oneofs: Vec<OneofIr>,
 
-    /// Single-item tuple defined types are inlined as their inner type.
+    /// Defined types that are represented as a field rather than a message
+    /// are inlined as their field label and inner type.
     ///
     /// For example, `optionBool` (a tuple with one bool) becomes a direct
-    /// `bool` field instead of a wrapper struct with `item_0`.
-    pub type_aliases: std::collections::HashMap<String, FieldTypeIr>,
+    /// `bool` field instead of a wrapper struct with `item_0`. Keeping the
+    /// label is important for aliases such as `Option<InlineStruct>` and
+    /// `Array<Tuple>`.
+    pub type_aliases: std::collections::HashMap<String, TypeAliasIr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -32,6 +35,12 @@ pub struct TypeIr {
 pub struct FieldIr {
     pub name: String,
     pub tag: u32,
+    pub label: LabelIr,
+    pub field_type: FieldTypeIr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeAliasIr {
     pub label: LabelIr,
     pub field_type: FieldTypeIr,
 }
@@ -147,16 +156,39 @@ impl SchemaIr {
         }
     }
 
-    /// If `ft` is a `Message` reference to a type alias, return the aliased
-    /// type. Otherwise return `ft` unchanged.
-    pub fn resolve_field_type(&self, ft: FieldTypeIr) -> FieldTypeIr {
-        if let FieldTypeIr::Message(ref name) = ft
-            && let Some(aliased) = self.type_aliases.get(name)
-        {
-            return aliased.clone();
+    /// Resolve a direct reference to a defined type alias.
+    ///
+    /// The alias label must be returned together with its field type. Using
+    /// only the inner type loses the wire-level Option/Array wrapper and can
+    /// make generated code deserialize the wrong bytes.
+    pub fn resolve_field(&self, label: LabelIr, field_type: FieldTypeIr) -> (LabelIr, FieldTypeIr) {
+        if !matches!(label, LabelIr::Singular) {
+            return (label, field_type);
         }
 
-        ft
+        let mut current_type = field_type;
+        let mut seen = std::collections::HashSet::new();
+
+        loop {
+            let FieldTypeIr::Message(name) = &current_type else {
+                return (LabelIr::Singular, current_type);
+            };
+
+            let Some(alias) = self.type_aliases.get(name) else {
+                return (LabelIr::Singular, current_type);
+            };
+
+            // Malformed/cyclic aliases should not make macro expansion loop.
+            if !seen.insert(name.clone()) {
+                return (LabelIr::Singular, current_type);
+            }
+
+            if !matches!(alias.label, LabelIr::Singular) {
+                return (alias.label.clone(), alias.field_type.clone());
+            }
+
+            current_type = alias.field_type.clone();
+        }
     }
 
     /// Collect the set of top-level (defined type / helper / account) names

--- a/crates/proc-macro/src/render/manual_prost.rs
+++ b/crates/proc-macro/src/render/manual_prost.rs
@@ -569,7 +569,7 @@ fn emit_prost_field_codegen(
         },
 
         // --- Optional message ---
-        (LabelIr::Optional, _) if is_message => {
+        (LabelIr::Optional(_), _) if is_message => {
             encode_stmts.push(quote! {
                 if let ::core::option::Option::Some(ref msg) = self.#fname {
                     ::prost::encoding::message::encode(#tag, msg, buf);
@@ -597,7 +597,7 @@ fn emit_prost_field_codegen(
         },
 
         // --- Optional pubkey (Pubkey ↔ PublicKeyProtoWrapper conversion) ---
-        (LabelIr::Optional, FieldTypeIr::Scalar(s)) if is_pubkey_scalar(s) => {
+        (LabelIr::Optional(_), FieldTypeIr::Scalar(s)) if is_pubkey_scalar(s) => {
             let pubkey_ty = map_ir_type_to_native(&f.field_type, in_module);
             let wrapper_ty = quote!(yellowstone_vixen_core::PublicKeyProtoWrapper);
 
@@ -639,7 +639,7 @@ fn emit_prost_field_codegen(
         },
 
         // --- Optional scalar (widened) ---
-        (LabelIr::Optional, FieldTypeIr::Scalar(s)) if needs_widening(s) => {
+        (LabelIr::Optional(_), FieldTypeIr::Scalar(s)) if needs_widening(s) => {
             let enc_mod = prost_encoding_mod(s);
             let wide_ty = widened_type(s);
             let native_ty = map_ir_type_to_native(&f.field_type, in_module);
@@ -676,7 +676,7 @@ fn emit_prost_field_codegen(
         },
 
         // --- Optional scalar (bytes conversion: u128/i128) ---
-        (LabelIr::Optional, FieldTypeIr::Scalar(s)) if needs_bytes_conversion(s) => {
+        (LabelIr::Optional(_), FieldTypeIr::Scalar(s)) if needs_bytes_conversion(s) => {
             let native_ty = bytes_native_type(s);
 
             encode_stmts.push(quote! {
@@ -717,7 +717,7 @@ fn emit_prost_field_codegen(
         },
 
         // --- Optional scalar (no widening) ---
-        (LabelIr::Optional, FieldTypeIr::Scalar(s)) => {
+        (LabelIr::Optional(_), FieldTypeIr::Scalar(s)) => {
             let enc_mod = prost_encoding_mod(s);
 
             encode_stmts.push(quote! {

--- a/crates/proc-macro/src/render/proto_schema_string.rs
+++ b/crates/proc-macro/src/render/proto_schema_string.rs
@@ -216,9 +216,9 @@ fn render_type(out: &mut String, msg: &TypeIr, proto_name: &str, rename: &HashMa
     writeln!(out, "message {} {{", proto_name).unwrap();
 
     for field in &msg.fields {
-        let label = match field.label {
+        let label = match &field.label {
             LabelIr::Singular => "",
-            LabelIr::Optional => "optional ",
+            LabelIr::Optional(_) => "optional ",
             LabelIr::Repeated | LabelIr::FixedArray(_) => "repeated ",
         };
 

--- a/crates/proc-macro/src/render/rust_types_from_ir.rs
+++ b/crates/proc-macro/src/render/rust_types_from_ir.rs
@@ -5,7 +5,8 @@ use quote::{format_ident, quote};
 use syn::LitStr;
 
 use crate::intermediate_representation::{
-    FieldIr, FieldTypeIr, LabelIr, OneofIr, OneofKindIr, ScalarIr, TypeIr, TypeKindIr,
+    FieldIr, FieldTypeIr, LabelIr, OneofIr, OneofKindIr, OptionEncodingIr, OptionPrefixIr,
+    ScalarIr, TypeIr, TypeKindIr,
 };
 
 // Generated types derive `serde::Serialize`/`Deserialize` behind the `serde` feature flag.
@@ -522,18 +523,24 @@ pub fn render_field(f: &FieldIr, local_names: Option<&HashSet<&str>>) -> TokenSt
     // With native types, we no longer need widening borsh attrs — only fixed-bytes,
     // float, and fixed-array helpers remain.
     let borsh_attr = {
-        let fixed = fixed_bytes_borsh_attrs(&f.label, &f.field_type, path_prefix);
+        let option = option_borsh_attrs(&f.label, &f.field_type, path_prefix);
 
-        if !fixed.is_empty() {
-            fixed
+        if !option.is_empty() {
+            option
         } else {
-            let float = float_borsh_attrs(&f.label, &f.field_type, path_prefix);
+            let fixed = fixed_bytes_borsh_attrs(&f.label, &f.field_type, path_prefix);
 
-            if !float.is_empty() {
-                float
+            if !fixed.is_empty() {
+                fixed
             } else {
-                // For FixedArray, we always need a custom borsh attr (no length prefix).
-                fixed_array_default_borsh_attrs(&f.label, path_prefix)
+                let float = float_borsh_attrs(&f.label, &f.field_type, path_prefix);
+
+                if !float.is_empty() {
+                    float
+                } else {
+                    // For FixedArray, we always need a custom borsh attr (no length prefix).
+                    fixed_array_default_borsh_attrs(&f.label, path_prefix)
+                }
             }
         }
     };
@@ -566,12 +573,12 @@ pub fn render_field(f: &FieldIr, local_names: Option<&HashSet<&str>>) -> TokenSt
 
             quote! { #borsh_attr pub #name: #rust_type }
         },
-        (LabelIr::Optional, FieldTypeIr::Message(msg)) => {
+        (LabelIr::Optional(_), FieldTypeIr::Message(msg)) => {
             let ty = resolve_msg(msg);
 
-            quote! { pub #name: ::core::option::Option<#ty> }
+            quote! { #borsh_attr pub #name: ::core::option::Option<#ty> }
         },
-        (LabelIr::Optional, field_type) => {
+        (LabelIr::Optional(_), field_type) => {
             let rust_type = map_ir_type_to_native(field_type, in_module);
 
             quote! { #borsh_attr pub #name: ::core::option::Option<#rust_type> }
@@ -586,6 +593,138 @@ pub fn render_field(f: &FieldIr, local_names: Option<&HashSet<&str>>) -> TokenSt
 
             quote! { #borsh_attr pub #name: Vec<#rust_type> }
         },
+    }
+}
+
+/// Returns custom Borsh hooks for Codama options that do not use Rust Borsh's
+/// native u8-tag encoding. This includes non-u8 prefixes and fixed options,
+/// whose `None` representation includes zero padding for the item size.
+fn option_borsh_attrs(label: &LabelIr, field_type: &FieldTypeIr, path_prefix: &str) -> TokenStream {
+    let LabelIr::Optional(encoding) = label else {
+        return quote! {};
+    };
+
+    if encoding.uses_native_borsh() {
+        return quote! {};
+    }
+
+    let padding = encoding.none_padding.unwrap_or(0);
+    let (deserialize, serialize) = option_borsh_paths(encoding, field_type, path_prefix, padding);
+    let deserialize = LitStr::new(&deserialize, Span::call_site());
+    let serialize = LitStr::new(&serialize, Span::call_site());
+
+    quote! {
+        #[borsh(
+            deserialize_with = #deserialize,
+            serialize_with = #serialize
+        )]
+    }
+}
+
+fn option_borsh_paths(
+    encoding: &OptionEncodingIr,
+    field_type: &FieldTypeIr,
+    path_prefix: &str,
+    padding: usize,
+) -> (String, String) {
+    let names = match field_type {
+        FieldTypeIr::Scalar(ScalarIr::FixedBytes(size)) => {
+            return option_fixed_bytes_borsh_paths(encoding, *size, path_prefix, padding);
+        },
+        FieldTypeIr::Scalar(ScalarIr::Float) => {
+            return option_float_borsh_paths(encoding, "f32", path_prefix, padding);
+        },
+        FieldTypeIr::Scalar(ScalarIr::Double) => {
+            return option_float_borsh_paths(encoding, "f64", path_prefix, padding);
+        },
+        _ => ("borsh_deserialize_option", "borsh_serialize_option"),
+    };
+
+    match &encoding.prefix {
+        OptionPrefixIr::FixedWidth {
+            byte_len,
+            one_value,
+            big_endian,
+        } => (
+            format!(
+                "{path_prefix}{}::<_, {byte_len}, {one_value}, {big_endian}, {padding}, _>",
+                names.0
+            ),
+            format!(
+                "{path_prefix}{}::<_, {byte_len}, {one_value}, {big_endian}, {padding}, _>",
+                names.1
+            ),
+        ),
+        OptionPrefixIr::ShortU16 => (
+            format!("{path_prefix}borsh_deserialize_short_u16_option::<_, {padding}, _>"),
+            format!("{path_prefix}borsh_serialize_short_u16_option::<_, {padding}, _>"),
+        ),
+    }
+}
+
+fn option_fixed_bytes_borsh_paths(
+    encoding: &OptionEncodingIr,
+    size: usize,
+    path_prefix: &str,
+    padding: usize,
+) -> (String, String) {
+    match &encoding.prefix {
+        OptionPrefixIr::FixedWidth {
+            byte_len,
+            one_value,
+            big_endian,
+        } => (
+            format!(
+                "{path_prefix}borsh_deserialize_option_fixed_bytes::<{size}, {byte_len}, \
+                 {one_value}, {big_endian}, {padding}, _>"
+            ),
+            format!(
+                "{path_prefix}borsh_serialize_option_fixed_bytes::<{size}, {byte_len}, \
+                 {one_value}, {big_endian}, {padding}, _>"
+            ),
+        ),
+        OptionPrefixIr::ShortU16 => (
+            format!(
+                "{path_prefix}borsh_deserialize_short_u16_option_fixed_bytes::<{size}, {padding}, \
+                 _>"
+            ),
+            format!(
+                "{path_prefix}borsh_serialize_short_u16_option_fixed_bytes::<{size}, {padding}, _>"
+            ),
+        ),
+    }
+}
+
+fn option_float_borsh_paths(
+    encoding: &OptionEncodingIr,
+    suffix: &str,
+    path_prefix: &str,
+    padding: usize,
+) -> (String, String) {
+    match &encoding.prefix {
+        OptionPrefixIr::FixedWidth {
+            byte_len,
+            one_value,
+            big_endian,
+        } => (
+            format!(
+                "{path_prefix}borsh_deserialize_option_{suffix}_permissive::<{byte_len}, \
+                 {one_value}, {big_endian}, {padding}, _>"
+            ),
+            format!(
+                "{path_prefix}borsh_serialize_option_{suffix}_permissive::<{byte_len}, \
+                 {one_value}, {big_endian}, {padding}, _>"
+            ),
+        ),
+        OptionPrefixIr::ShortU16 => (
+            format!(
+                "{path_prefix}borsh_deserialize_short_u16_option_{suffix}_permissive::<{padding}, \
+                 _>"
+            ),
+            format!(
+                "{path_prefix}borsh_serialize_short_u16_option_{suffix}_permissive::<{padding}, _>"
+            ),
+        ),
     }
 }
 
@@ -646,7 +785,7 @@ fn fixed_bytes_borsh_attrs(
                 serialize_with = #serialize_path
             )]
         },
-        LabelIr::Optional => quote! {
+        LabelIr::Optional(_) => quote! {
             #[borsh(
                 deserialize_with = #deserialize_opt_path,
                 serialize_with = #serialize_opt_path
@@ -693,7 +832,7 @@ fn float_borsh_attrs(label: &LabelIr, field_type: &FieldTypeIr, path_prefix: &st
             format!("{path_prefix}borsh_deserialize_{suffix}_permissive"),
             format!("{path_prefix}borsh_serialize_{suffix}_permissive"),
         ),
-        LabelIr::Optional => (
+        LabelIr::Optional(_) => (
             format!("{path_prefix}borsh_deserialize_opt_{suffix}_permissive"),
             format!("{path_prefix}borsh_serialize_opt_{suffix}_permissive"),
         ),

--- a/crates/proc-macro/src/render/vixen_parser.rs
+++ b/crates/proc-macro/src/render/vixen_parser.rs
@@ -34,6 +34,21 @@ pub fn vixen_parser(idl: &RootNode, events: &[EventNode], config: &ParserConfig)
     let schema_ir = crate::intermediate_representation::build_schema_ir(idl, events);
 
     let schema_types = crate::render::rust_types_from_ir(&schema_ir);
+    let option_borsh_helpers = if schema_ir
+        .types
+        .iter()
+        .flat_map(|type_ir| &type_ir.fields)
+        .any(|field| {
+            matches!(
+                &field.label,
+                crate::intermediate_representation::LabelIr::Optional(encoding)
+                    if !encoding.uses_native_borsh()
+            )
+        }) {
+        option_borsh_helpers()
+    } else {
+        quote! {}
+    };
 
     let account_parser = crate::render::account_parser(&idl.program.name, &idl.program.accounts);
 
@@ -118,6 +133,8 @@ pub fn vixen_parser(idl: &RootNode, events: &[EventNode], config: &ParserConfig)
             use yellowstone_vixen_parser::prelude::*;
 
             pub use yellowstone_vixen_core::Pubkey;
+
+            #option_borsh_helpers
 
             /// Borsh: deserialize N fixed bytes into `Vec<u8>`.
             /// On-chain, fixed-size byte fields (pubkeys, u128, fixed arrays) have no
@@ -493,6 +510,446 @@ pub fn vixen_parser(idl: &RootNode, events: &[EventNode], config: &ParserConfig)
             #account_parser
             #instruction_parser
             #event_parser
+        }
+    }
+}
+
+fn option_borsh_helpers() -> TokenStream {
+    quote! {
+        fn borsh_deserialize_option_prefix<
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<bool, ::borsh::io::Error> {
+            let mut bytes = [0u8; PREFIX_BYTES];
+            reader.read_exact(&mut bytes)?;
+
+            let mut value = 0u128;
+            for (index, byte) in bytes.iter().enumerate() {
+                let shift = if BIG_ENDIAN {
+                    (PREFIX_BYTES - index - 1) * 8
+                } else {
+                    index * 8
+                };
+                value |= u128::from(*byte) << shift;
+            }
+
+            if value == 0 {
+                ::core::result::Result::Ok(false)
+            } else if value == PREFIX_ONE {
+                ::core::result::Result::Ok(true)
+            } else {
+                ::core::result::Result::Err(::borsh::io::Error::new(
+                    ::borsh::io::ErrorKind::InvalidData,
+                    "invalid Codama option prefix",
+                ))
+            }
+        }
+
+        fn borsh_serialize_option_prefix<
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            W: ::borsh::io::Write,
+        >(
+            is_some: bool,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            let value = if is_some { PREFIX_ONE } else { 0 };
+            let mut bytes = [0u8; PREFIX_BYTES];
+
+            for (index, byte) in bytes.iter_mut().enumerate() {
+                let shift = if BIG_ENDIAN {
+                    (PREFIX_BYTES - index - 1) * 8
+                } else {
+                    index * 8
+                };
+                *byte = ((value >> shift) & 0xff) as u8;
+            }
+
+            writer.write_all(&bytes)
+        }
+
+        fn borsh_deserialize_option_none_padding<
+            const NONE_PADDING: usize,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            let mut padding = ::std::vec![0u8; NONE_PADDING];
+            reader.read_exact(&mut padding)?;
+
+            if padding.iter().all(|byte| *byte == 0) {
+                ::core::result::Result::Ok(())
+            } else {
+                ::core::result::Result::Err(::borsh::io::Error::new(
+                    ::borsh::io::ErrorKind::InvalidData,
+                    "fixed Codama option padding must be zero",
+                ))
+            }
+        }
+
+        fn borsh_serialize_option_none_padding<
+            const NONE_PADDING: usize,
+            W: ::borsh::io::Write,
+        >(
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            writer.write_all(&::std::vec![0u8; NONE_PADDING])
+        }
+
+        fn borsh_deserialize_option<
+            T: ::borsh::BorshDeserialize,
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            const NONE_PADDING: usize,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<::core::option::Option<T>, ::borsh::io::Error> {
+            if borsh_deserialize_option_prefix::<PREFIX_BYTES, PREFIX_ONE, BIG_ENDIAN, _>(reader)? {
+                ::core::result::Result::Ok(::core::option::Option::Some(
+                    <T as ::borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                ))
+            } else {
+                borsh_deserialize_option_none_padding::<NONE_PADDING, _>(reader)?;
+                ::core::result::Result::Ok(::core::option::Option::None)
+            }
+        }
+
+        fn borsh_serialize_option<
+            T: ::borsh::BorshSerialize,
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            const NONE_PADDING: usize,
+            W: ::borsh::io::Write,
+        >(
+            value: &::core::option::Option<T>,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            borsh_serialize_option_prefix::<PREFIX_BYTES, PREFIX_ONE, BIG_ENDIAN, _>(
+                value.is_some(),
+                writer,
+            )?;
+
+            match value {
+                ::core::option::Option::Some(value) => {
+                    <T as ::borsh::BorshSerialize>::serialize(value, writer)
+                }
+                ::core::option::Option::None => {
+                    borsh_serialize_option_none_padding::<NONE_PADDING, _>(writer)
+                }
+            }
+        }
+
+        fn borsh_deserialize_option_fixed_bytes<
+            const BYTE_SIZE: usize,
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            const NONE_PADDING: usize,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<::core::option::Option<Vec<u8>>, ::borsh::io::Error> {
+            if borsh_deserialize_option_prefix::<PREFIX_BYTES, PREFIX_ONE, BIG_ENDIAN, _>(reader)? {
+                let mut bytes = [0u8; BYTE_SIZE];
+                reader.read_exact(&mut bytes)?;
+                ::core::result::Result::Ok(::core::option::Option::Some(bytes.to_vec()))
+            } else {
+                borsh_deserialize_option_none_padding::<NONE_PADDING, _>(reader)?;
+                ::core::result::Result::Ok(::core::option::Option::None)
+            }
+        }
+
+        fn borsh_serialize_option_fixed_bytes<
+            const BYTE_SIZE: usize,
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            const NONE_PADDING: usize,
+            W: ::borsh::io::Write,
+        >(
+            value: &::core::option::Option<Vec<u8>>,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            borsh_serialize_option_prefix::<PREFIX_BYTES, PREFIX_ONE, BIG_ENDIAN, _>(
+                value.is_some(),
+                writer,
+            )?;
+
+            match value {
+                ::core::option::Option::Some(value) if value.len() == BYTE_SIZE => {
+                    writer.write_all(value)
+                }
+                ::core::option::Option::Some(_) => ::core::result::Result::Err(
+                    ::borsh::io::Error::new(
+                        ::borsh::io::ErrorKind::InvalidInput,
+                        "invalid fixed-byte option length",
+                    ),
+                ),
+                ::core::option::Option::None => {
+                    borsh_serialize_option_none_padding::<NONE_PADDING, _>(writer)
+                }
+            }
+        }
+
+        fn borsh_deserialize_option_f32_permissive<
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            const NONE_PADDING: usize,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<::core::option::Option<f32>, ::borsh::io::Error> {
+            if borsh_deserialize_option_prefix::<PREFIX_BYTES, PREFIX_ONE, BIG_ENDIAN, _>(reader)? {
+                let mut bytes = [0u8; 4];
+                reader.read_exact(&mut bytes)?;
+                ::core::result::Result::Ok(::core::option::Option::Some(f32::from_le_bytes(bytes)))
+            } else {
+                borsh_deserialize_option_none_padding::<NONE_PADDING, _>(reader)?;
+                ::core::result::Result::Ok(::core::option::Option::None)
+            }
+        }
+
+        fn borsh_serialize_option_f32_permissive<
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            const NONE_PADDING: usize,
+            W: ::borsh::io::Write,
+        >(
+            value: &::core::option::Option<f32>,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            borsh_serialize_option_prefix::<PREFIX_BYTES, PREFIX_ONE, BIG_ENDIAN, _>(
+                value.is_some(),
+                writer,
+            )?;
+
+            match value {
+                ::core::option::Option::Some(value) => writer.write_all(&value.to_le_bytes()),
+                ::core::option::Option::None => {
+                    borsh_serialize_option_none_padding::<NONE_PADDING, _>(writer)
+                }
+            }
+        }
+
+        fn borsh_deserialize_option_f64_permissive<
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            const NONE_PADDING: usize,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<::core::option::Option<f64>, ::borsh::io::Error> {
+            if borsh_deserialize_option_prefix::<PREFIX_BYTES, PREFIX_ONE, BIG_ENDIAN, _>(reader)? {
+                let mut bytes = [0u8; 8];
+                reader.read_exact(&mut bytes)?;
+                ::core::result::Result::Ok(::core::option::Option::Some(f64::from_le_bytes(bytes)))
+            } else {
+                borsh_deserialize_option_none_padding::<NONE_PADDING, _>(reader)?;
+                ::core::result::Result::Ok(::core::option::Option::None)
+            }
+        }
+
+        fn borsh_serialize_option_f64_permissive<
+            const PREFIX_BYTES: usize,
+            const PREFIX_ONE: u128,
+            const BIG_ENDIAN: bool,
+            const NONE_PADDING: usize,
+            W: ::borsh::io::Write,
+        >(
+            value: &::core::option::Option<f64>,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            borsh_serialize_option_prefix::<PREFIX_BYTES, PREFIX_ONE, BIG_ENDIAN, _>(
+                value.is_some(),
+                writer,
+            )?;
+
+            match value {
+                ::core::option::Option::Some(value) => writer.write_all(&value.to_le_bytes()),
+                ::core::option::Option::None => {
+                    borsh_serialize_option_none_padding::<NONE_PADDING, _>(writer)
+                }
+            }
+        }
+
+        fn borsh_deserialize_short_u16_option_prefix<R: ::borsh::io::Read>(
+            reader: &mut R,
+        ) -> ::core::result::Result<bool, ::borsh::io::Error> {
+            let mut byte = [0u8; 1];
+            reader.read_exact(&mut byte)?;
+
+            match byte[0] {
+                0 => ::core::result::Result::Ok(false),
+                1 => ::core::result::Result::Ok(true),
+                _ => ::core::result::Result::Err(::borsh::io::Error::new(
+                    ::borsh::io::ErrorKind::InvalidData,
+                    "invalid short_u16 Codama option prefix",
+                )),
+            }
+        }
+
+        fn borsh_serialize_short_u16_option_prefix<W: ::borsh::io::Write>(
+            is_some: bool,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            writer.write_all(&[u8::from(is_some)])
+        }
+
+        fn borsh_deserialize_short_u16_option<
+            T: ::borsh::BorshDeserialize,
+            const NONE_PADDING: usize,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<::core::option::Option<T>, ::borsh::io::Error> {
+            if borsh_deserialize_short_u16_option_prefix(reader)? {
+                ::core::result::Result::Ok(::core::option::Option::Some(
+                    <T as ::borsh::BorshDeserialize>::deserialize_reader(reader)?,
+                ))
+            } else {
+                borsh_deserialize_option_none_padding::<NONE_PADDING, _>(reader)?;
+                ::core::result::Result::Ok(::core::option::Option::None)
+            }
+        }
+
+        fn borsh_serialize_short_u16_option<
+            T: ::borsh::BorshSerialize,
+            const NONE_PADDING: usize,
+            W: ::borsh::io::Write,
+        >(
+            value: &::core::option::Option<T>,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            borsh_serialize_short_u16_option_prefix(value.is_some(), writer)?;
+
+            match value {
+                ::core::option::Option::Some(value) => {
+                    <T as ::borsh::BorshSerialize>::serialize(value, writer)
+                }
+                ::core::option::Option::None => {
+                    borsh_serialize_option_none_padding::<NONE_PADDING, _>(writer)
+                }
+            }
+        }
+
+        fn borsh_deserialize_short_u16_option_fixed_bytes<
+            const BYTE_SIZE: usize,
+            const NONE_PADDING: usize,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<::core::option::Option<Vec<u8>>, ::borsh::io::Error> {
+            if borsh_deserialize_short_u16_option_prefix(reader)? {
+                let mut bytes = [0u8; BYTE_SIZE];
+                reader.read_exact(&mut bytes)?;
+                ::core::result::Result::Ok(::core::option::Option::Some(bytes.to_vec()))
+            } else {
+                borsh_deserialize_option_none_padding::<NONE_PADDING, _>(reader)?;
+                ::core::result::Result::Ok(::core::option::Option::None)
+            }
+        }
+
+        fn borsh_serialize_short_u16_option_fixed_bytes<
+            const BYTE_SIZE: usize,
+            const NONE_PADDING: usize,
+            W: ::borsh::io::Write,
+        >(
+            value: &::core::option::Option<Vec<u8>>,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            borsh_serialize_short_u16_option_prefix(value.is_some(), writer)?;
+
+            match value {
+                ::core::option::Option::Some(value) if value.len() == BYTE_SIZE => {
+                    writer.write_all(value)
+                }
+                ::core::option::Option::Some(_) => ::core::result::Result::Err(
+                    ::borsh::io::Error::new(
+                        ::borsh::io::ErrorKind::InvalidInput,
+                        "invalid fixed-byte option length",
+                    ),
+                ),
+                ::core::option::Option::None => {
+                    borsh_serialize_option_none_padding::<NONE_PADDING, _>(writer)
+                }
+            }
+        }
+
+        fn borsh_deserialize_short_u16_option_f32_permissive<
+            const NONE_PADDING: usize,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<::core::option::Option<f32>, ::borsh::io::Error> {
+            if borsh_deserialize_short_u16_option_prefix(reader)? {
+                let mut bytes = [0u8; 4];
+                reader.read_exact(&mut bytes)?;
+                ::core::result::Result::Ok(::core::option::Option::Some(f32::from_le_bytes(bytes)))
+            } else {
+                borsh_deserialize_option_none_padding::<NONE_PADDING, _>(reader)?;
+                ::core::result::Result::Ok(::core::option::Option::None)
+            }
+        }
+
+        fn borsh_serialize_short_u16_option_f32_permissive<
+            const NONE_PADDING: usize,
+            W: ::borsh::io::Write,
+        >(
+            value: &::core::option::Option<f32>,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            borsh_serialize_short_u16_option_prefix(value.is_some(), writer)?;
+
+            match value {
+                ::core::option::Option::Some(value) => writer.write_all(&value.to_le_bytes()),
+                ::core::option::Option::None => {
+                    borsh_serialize_option_none_padding::<NONE_PADDING, _>(writer)
+                }
+            }
+        }
+
+        fn borsh_deserialize_short_u16_option_f64_permissive<
+            const NONE_PADDING: usize,
+            R: ::borsh::io::Read,
+        >(
+            reader: &mut R,
+        ) -> ::core::result::Result<::core::option::Option<f64>, ::borsh::io::Error> {
+            if borsh_deserialize_short_u16_option_prefix(reader)? {
+                let mut bytes = [0u8; 8];
+                reader.read_exact(&mut bytes)?;
+                ::core::result::Result::Ok(::core::option::Option::Some(f64::from_le_bytes(bytes)))
+            } else {
+                borsh_deserialize_option_none_padding::<NONE_PADDING, _>(reader)?;
+                ::core::result::Result::Ok(::core::option::Option::None)
+            }
+        }
+
+        fn borsh_serialize_short_u16_option_f64_permissive<
+            const NONE_PADDING: usize,
+            W: ::borsh::io::Write,
+        >(
+            value: &::core::option::Option<f64>,
+            writer: &mut W,
+        ) -> ::core::result::Result<(), ::borsh::io::Error> {
+            borsh_serialize_short_u16_option_prefix(value.is_some(), writer)?;
+
+            match value {
+                ::core::option::Option::Some(value) => writer.write_all(&value.to_le_bytes()),
+                ::core::option::Option::None => {
+                    borsh_serialize_option_none_padding::<NONE_PADDING, _>(writer)
+                }
+            }
         }
     }
 }

--- a/tests/common/src/lib.rs
+++ b/tests/common/src/lib.rs
@@ -51,3 +51,12 @@ pub fn check_protobuf_format(schema: &str) {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+/// Normalize whitespace that is irrelevant to the protobuf schema snapshots.
+pub fn normalize_protobuf_schema_for_snapshot(schema: &str) -> String {
+    schema
+        .split('\n')
+        .map(|line| line.trim_end_matches([' ', '\t']))
+        .collect::<Vec<_>>()
+        .join("\n")
+}

--- a/tests/idls/inline_struct.json
+++ b/tests/idls/inline_struct.json
@@ -333,6 +333,15 @@
               "kind": "definedTypeLinkNode",
               "name": "definedNested"
             }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "firstAlias",
+            "docs": [],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "firstAlias"
+            }
           }
         ],
         "discriminators": [
@@ -439,6 +448,89 @@
               "kind": "fixedCountNode",
               "value": 2
             }
+          },
+          "prefix": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "foo",
+        "docs": [],
+        "type": {
+          "kind": "optionTypeNode",
+          "fixed": false,
+          "item": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "numberTypeNode",
+              "format": "u8",
+              "endian": "le"
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 2
+            }
+          },
+          "prefix": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "fooOption",
+        "docs": [],
+        "type": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "code",
+              "docs": [],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "firstAlias",
+        "docs": [],
+        "type": {
+          "kind": "optionTypeNode",
+          "fixed": false,
+          "item": {
+            "kind": "definedTypeLinkNode",
+            "name": "secondAlias"
+          },
+          "prefix": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "secondAlias",
+        "docs": [],
+        "type": {
+          "kind": "optionTypeNode",
+          "fixed": false,
+          "item": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
           },
           "prefix": {
             "kind": "numberTypeNode",

--- a/tests/idls/inline_struct.json
+++ b/tests/idls/inline_struct.json
@@ -224,6 +224,62 @@
                 "endian": "le"
               }
             }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "foo",
+            "docs": [],
+            "type": {
+              "kind": "optionTypeNode",
+              "fixed": false,
+              "item": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "structTypeNode",
+                  "fields": [
+                    {
+                      "kind": "structFieldTypeNode",
+                      "name": "code",
+                      "docs": [],
+                      "type": {
+                        "kind": "numberTypeNode",
+                        "format": "u8",
+                        "endian": "le"
+                      }
+                    }
+                  ]
+                },
+                "count": {
+                  "kind": "fixedCountNode",
+                  "value": 1
+                }
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "fooOption",
+            "docs": [],
+            "type": {
+              "kind": "structTypeNode",
+              "fields": [
+                {
+                  "kind": "structFieldTypeNode",
+                  "name": "code",
+                  "docs": [],
+                  "type": {
+                    "kind": "numberTypeNode",
+                    "format": "u8",
+                    "endian": "le"
+                  }
+                }
+              ]
+            }
           }
         ],
         "discriminators": [

--- a/tests/idls/inline_struct.json
+++ b/tests/idls/inline_struct.json
@@ -1,0 +1,122 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.6.0",
+  "program": {
+    "kind": "programNode",
+    "name": "inlineStruct",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.1.0",
+    "origin": "custom",
+    "docs": [],
+    "accounts": [],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "name": "setMetadata",
+        "docs": [],
+        "optionalAccountStrategy": "programId",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "metadataName",
+            "docs": [],
+            "type": {
+              "kind": "structTypeNode",
+              "fields": [
+                {
+                  "kind": "structFieldTypeNode",
+                  "name": "len",
+                  "docs": [],
+                  "type": {
+                    "kind": "numberTypeNode",
+                    "format": "u8",
+                    "endian": "le"
+                  }
+                },
+                {
+                  "kind": "structFieldTypeNode",
+                  "name": "value",
+                  "docs": [],
+                  "type": {
+                    "kind": "fixedSizeTypeNode",
+                    "size": 25,
+                    "type": {
+                      "kind": "stringTypeNode",
+                      "encoding": "utf8"
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "optionalMetadata",
+            "docs": [],
+            "type": {
+              "kind": "optionTypeNode",
+              "fixed": true,
+              "item": {
+                "kind": "structTypeNode",
+                "fields": [
+                  {
+                    "kind": "structFieldTypeNode",
+                    "name": "len",
+                    "docs": [],
+                    "type": {
+                      "kind": "numberTypeNode",
+                      "format": "u8",
+                      "endian": "le"
+                    }
+                  },
+                  {
+                    "kind": "structFieldTypeNode",
+                    "name": "value",
+                    "docs": [],
+                    "type": {
+                      "kind": "fixedSizeTypeNode",
+                      "size": 5,
+                      "type": {
+                        "kind": "stringTypeNode",
+                        "encoding": "utf8"
+                      }
+                    }
+                  }
+                ]
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "constantDiscriminatorNode",
+            "offset": 0,
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "kind": "bytesValueNode",
+                "data": "01",
+                "encoding": "base16"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "definedTypes": [],
+    "errors": [],
+    "pdas": [],
+    "events": []
+  },
+  "additionalPrograms": []
+}

--- a/tests/idls/inline_struct.json
+++ b/tests/idls/inline_struct.json
@@ -92,6 +92,138 @@
                 "endian": "le"
               }
             }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "arrayMetadata",
+            "docs": [],
+            "type": {
+              "kind": "arrayTypeNode",
+              "item": {
+                "kind": "structTypeNode",
+                "fields": [
+                  {
+                    "kind": "structFieldTypeNode",
+                    "name": "code",
+                    "docs": [],
+                    "type": {
+                      "kind": "numberTypeNode",
+                      "format": "u8",
+                      "endian": "le"
+                    }
+                  },
+                  {
+                    "kind": "structFieldTypeNode",
+                    "name": "value",
+                    "docs": [],
+                    "type": {
+                      "kind": "fixedSizeTypeNode",
+                      "size": 3,
+                      "type": {
+                        "kind": "stringTypeNode",
+                        "encoding": "utf8"
+                      }
+                    }
+                  }
+                ]
+              },
+              "count": {
+                "kind": "fixedCountNode",
+                "value": 2
+              }
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "tupleMetadata",
+            "docs": [],
+            "type": {
+              "kind": "tupleTypeNode",
+              "items": [
+                {
+                  "kind": "structTypeNode",
+                  "fields": [
+                    {
+                      "kind": "structFieldTypeNode",
+                      "name": "code",
+                      "docs": [],
+                      "type": {
+                        "kind": "numberTypeNode",
+                        "format": "u8",
+                        "endian": "le"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "kind": "arrayTypeNode",
+                  "item": {
+                    "kind": "optionTypeNode",
+                    "fixed": false,
+                    "item": {
+                      "kind": "structTypeNode",
+                      "fields": [
+                        {
+                          "kind": "structFieldTypeNode",
+                          "name": "value",
+                          "docs": [],
+                          "type": {
+                            "kind": "numberTypeNode",
+                            "format": "u16",
+                            "endian": "le"
+                          }
+                        }
+                      ]
+                    },
+                    "prefix": {
+                      "kind": "numberTypeNode",
+                      "format": "u8",
+                      "endian": "le"
+                    }
+                  },
+                  "count": {
+                    "kind": "fixedCountNode",
+                    "value": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "optionalArrayMetadata",
+            "docs": [],
+            "type": {
+              "kind": "optionTypeNode",
+              "fixed": false,
+              "item": {
+                "kind": "arrayTypeNode",
+                "item": {
+                  "kind": "structTypeNode",
+                  "fields": [
+                    {
+                      "kind": "structFieldTypeNode",
+                      "name": "value",
+                      "docs": [],
+                      "type": {
+                        "kind": "numberTypeNode",
+                        "format": "u32",
+                        "endian": "le"
+                      }
+                    }
+                  ]
+                },
+                "count": {
+                  "kind": "fixedCountNode",
+                  "value": 2
+                }
+              },
+              "prefix": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
           }
         ],
         "discriminators": [

--- a/tests/idls/inline_struct.json
+++ b/tests/idls/inline_struct.json
@@ -299,9 +299,155 @@
             }
           }
         ]
+      },
+      {
+        "kind": "instructionNode",
+        "name": "useDefinedAliases",
+        "docs": [],
+        "optionalAccountStrategy": "programId",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "definedOptional",
+            "docs": [],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "definedOptional"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "definedTupleArray",
+            "docs": [],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "definedTupleArray"
+            }
+          },
+          {
+            "kind": "instructionArgumentNode",
+            "name": "definedNested",
+            "docs": [],
+            "type": {
+              "kind": "definedTypeLinkNode",
+              "name": "definedNested"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "constantDiscriminatorNode",
+            "offset": 0,
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "kind": "bytesValueNode",
+                "data": "02",
+                "encoding": "base16"
+              }
+            }
+          }
+        ]
       }
     ],
-    "definedTypes": [],
+    "definedTypes": [
+      {
+        "kind": "definedTypeNode",
+        "name": "definedOptional",
+        "docs": [],
+        "type": {
+          "kind": "optionTypeNode",
+          "fixed": false,
+          "item": {
+            "kind": "structTypeNode",
+            "fields": [
+              {
+                "kind": "structFieldTypeNode",
+                "name": "code",
+                "docs": [],
+                "type": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                }
+              }
+            ]
+          },
+          "prefix": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "definedTupleArray",
+        "docs": [],
+        "type": {
+          "kind": "arrayTypeNode",
+          "item": {
+            "kind": "tupleTypeNode",
+            "items": [
+              {
+                "kind": "numberTypeNode",
+                "format": "u16",
+                "endian": "le"
+              },
+              {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            ]
+          },
+          "count": {
+            "kind": "fixedCountNode",
+            "value": 2
+          }
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "definedNested",
+        "docs": [],
+        "type": {
+          "kind": "optionTypeNode",
+          "fixed": false,
+          "item": {
+            "kind": "arrayTypeNode",
+            "item": {
+              "kind": "structTypeNode",
+              "fields": [
+                {
+                  "kind": "structFieldTypeNode",
+                  "name": "value",
+                  "docs": [],
+                  "type": {
+                    "kind": "numberTypeNode",
+                    "format": "u32",
+                    "endian": "le"
+                  }
+                }
+              ]
+            },
+            "count": {
+              "kind": "fixedCountNode",
+              "value": 2
+            }
+          },
+          "prefix": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      }
+    ],
     "errors": [],
     "pdas": [],
     "events": []

--- a/tests/idls/inline_struct_collisions.json
+++ b/tests/idls/inline_struct_collisions.json
@@ -1,0 +1,139 @@
+{
+  "kind": "rootNode",
+  "standard": "codama",
+  "version": "1.6.0",
+  "program": {
+    "kind": "programNode",
+    "name": "inlineStructCollisions",
+    "publicKey": "11111111111111111111111111111111",
+    "version": "0.1.0",
+    "origin": "custom",
+    "docs": [],
+    "accounts": [
+      {
+        "kind": "accountNode",
+        "name": "bar",
+        "size": 1,
+        "docs": [],
+        "data": {
+          "kind": "structTypeNode",
+          "fields": [
+            {
+              "kind": "structFieldTypeNode",
+              "name": "accountValue",
+              "docs": [],
+              "type": {
+                "kind": "numberTypeNode",
+                "format": "u8",
+                "endian": "le"
+              }
+            }
+          ]
+        },
+        "discriminators": []
+      }
+    ],
+    "instructions": [
+      {
+        "kind": "instructionNode",
+        "name": "foo",
+        "docs": [],
+        "optionalAccountStrategy": "programId",
+        "accounts": [],
+        "arguments": [
+          {
+            "kind": "instructionArgumentNode",
+            "name": "amount",
+            "docs": [],
+            "type": {
+              "kind": "numberTypeNode",
+              "format": "u64",
+              "endian": "le"
+            }
+          }
+        ],
+        "discriminators": [
+          {
+            "kind": "constantDiscriminatorNode",
+            "offset": 0,
+            "constant": {
+              "kind": "constantValueNode",
+              "type": {
+                "kind": "bytesTypeNode"
+              },
+              "value": {
+                "kind": "bytesValueNode",
+                "data": "01",
+                "encoding": "base16"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "definedTypes": [
+      {
+        "kind": "definedTypeNode",
+        "name": "fooArgs",
+        "docs": [],
+        "type": {
+          "kind": "optionTypeNode",
+          "fixed": false,
+          "item": {
+            "kind": "structTypeNode",
+            "fields": [
+              {
+                "kind": "structFieldTypeNode",
+                "name": "code",
+                "docs": [],
+                "type": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                }
+              }
+            ]
+          },
+          "prefix": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      },
+      {
+        "kind": "definedTypeNode",
+        "name": "bar",
+        "docs": [],
+        "type": {
+          "kind": "optionTypeNode",
+          "fixed": false,
+          "item": {
+            "kind": "structTypeNode",
+            "fields": [
+              {
+                "kind": "structFieldTypeNode",
+                "name": "code",
+                "docs": [],
+                "type": {
+                  "kind": "numberTypeNode",
+                  "format": "u8",
+                  "endian": "le"
+                }
+              }
+            ]
+          },
+          "prefix": {
+            "kind": "numberTypeNode",
+            "format": "u8",
+            "endian": "le"
+          }
+        }
+      }
+    ],
+    "errors": [],
+    "pdas": [],
+    "events": []
+  },
+  "additionalPrograms": []
+}

--- a/tests/proc-macro/tests/inline_struct.rs
+++ b/tests/proc-macro/tests/inline_struct.rs
@@ -21,6 +21,8 @@ fn check_protobuf_schema() {
         .contains("message SetMetadataArgsTupleMetadataTupleItem1Inner"));
     assert!(inline_struct::PROTOBUF_SCHEMA
         .contains("message SetMetadataArgsOptionalArrayMetadataOption"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsFooOption"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsFooOption2"));
 }
 
 #[test]
@@ -30,8 +32,10 @@ fn inline_structs_are_generated_as_messages() {
     assert_eq!(args.metadata_name.len, 0);
     assert!(args.optional_metadata.is_none());
     assert!(args.array_metadata.is_empty());
-    assert!(args.tuple_metadata.is_none());
+    assert_eq!(args.tuple_metadata.item_0.code, 0);
     assert!(args.optional_array_metadata.is_none());
+    assert!(args.foo.is_none());
+    assert_eq!(args.foo_option.code, 0);
 }
 
 #[test]
@@ -57,7 +61,7 @@ fn nested_inline_structs_round_trip_borsh() {
                 value: vec![b'd'; 3],
             },
         ],
-        tuple_metadata: Some(inline_struct::SetMetadataArgsTupleMetadataTuple {
+        tuple_metadata: inline_struct::SetMetadataArgsTupleMetadataTuple {
             item_0: inline_struct::SetMetadataArgsTupleMetadataTupleItem0 { code: 7 },
             item_1: vec![
                 inline_struct::SetMetadataArgsTupleMetadataTupleItem1Inner {
@@ -67,17 +71,63 @@ fn nested_inline_structs_round_trip_borsh() {
                 },
                 inline_struct::SetMetadataArgsTupleMetadataTupleItem1Inner { items: None },
             ],
-        }),
+        },
         optional_array_metadata: Some(inline_struct::SetMetadataArgsOptionalArrayMetadataOption {
             value: vec![
                 inline_struct::SetMetadataArgsOptionalArrayMetadataValue { value: 9 },
                 inline_struct::SetMetadataArgsOptionalArrayMetadataValue { value: 10 },
             ],
         }),
+        foo: None,
+        foo_option: inline_struct::SetMetadataArgsFooOption2 { code: 11 },
     };
 
     let encoded = borsh::to_vec(&args).unwrap();
     let decoded = inline_struct::instruction::SetMetadataArgs::try_from_slice(&encoded).unwrap();
 
     assert_eq!(decoded, args);
+}
+
+#[test]
+fn bare_tuple_deserializes_exact_borsh_wire() {
+    use borsh::BorshDeserialize;
+
+    // The tuple begins with `code = 7`, rather than an Option discriminator.
+    let encoded = [
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, b'a',
+        b'a', b'a', 2, b'b', b'b', b'b', 7, 1, 8, 0, 0, 0, 0, 42,
+    ];
+    let decoded = inline_struct::instruction::SetMetadataArgs::try_from_slice(&encoded).unwrap();
+
+    assert_eq!(decoded, inline_struct::instruction::SetMetadataArgs {
+        metadata_name: inline_struct::SetMetadataArgsMetadataName {
+            len: 0,
+            value: vec![0; 25],
+        },
+        optional_metadata: None,
+        array_metadata: vec![
+            inline_struct::SetMetadataArgsArrayMetadata {
+                code: 1,
+                value: vec![b'a'; 3],
+            },
+            inline_struct::SetMetadataArgsArrayMetadata {
+                code: 2,
+                value: vec![b'b'; 3],
+            },
+        ],
+        tuple_metadata: inline_struct::SetMetadataArgsTupleMetadataTuple {
+            item_0: inline_struct::SetMetadataArgsTupleMetadataTupleItem0 { code: 7 },
+            item_1: vec![
+                inline_struct::SetMetadataArgsTupleMetadataTupleItem1Inner {
+                    items: Some(inline_struct::SetMetadataArgsTupleMetadataTupleItem1Item {
+                        value: 8,
+                    }),
+                },
+                inline_struct::SetMetadataArgsTupleMetadataTupleItem1Inner { items: None },
+            ],
+        },
+        optional_array_metadata: None,
+        foo: None,
+        foo_option: inline_struct::SetMetadataArgsFooOption2 { code: 42 },
+    });
 }

--- a/tests/proc-macro/tests/inline_struct.rs
+++ b/tests/proc-macro/tests/inline_struct.rs
@@ -15,6 +15,12 @@ fn check_protobuf_schema() {
 
     assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsMetadataName"));
     assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsOptionalMetadata"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsArrayMetadata"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsTupleMetadataTuple"));
+    assert!(inline_struct::PROTOBUF_SCHEMA
+        .contains("message SetMetadataArgsTupleMetadataTupleItem1Inner"));
+    assert!(inline_struct::PROTOBUF_SCHEMA
+        .contains("message SetMetadataArgsOptionalArrayMetadataOption"));
 }
 
 #[test]
@@ -23,4 +29,55 @@ fn inline_structs_are_generated_as_messages() {
 
     assert_eq!(args.metadata_name.len, 0);
     assert!(args.optional_metadata.is_none());
+    assert!(args.array_metadata.is_empty());
+    assert!(args.tuple_metadata.is_none());
+    assert!(args.optional_array_metadata.is_none());
+}
+
+#[test]
+fn nested_inline_structs_round_trip_borsh() {
+    use borsh::BorshDeserialize;
+
+    let args = inline_struct::instruction::SetMetadataArgs {
+        metadata_name: inline_struct::SetMetadataArgsMetadataName {
+            len: 3,
+            value: vec![b'a'; 25],
+        },
+        optional_metadata: Some(inline_struct::SetMetadataArgsOptionalMetadata {
+            len: 2,
+            value: vec![b'b'; 5],
+        }),
+        array_metadata: vec![
+            inline_struct::SetMetadataArgsArrayMetadata {
+                code: 1,
+                value: vec![b'c'; 3],
+            },
+            inline_struct::SetMetadataArgsArrayMetadata {
+                code: 2,
+                value: vec![b'd'; 3],
+            },
+        ],
+        tuple_metadata: Some(inline_struct::SetMetadataArgsTupleMetadataTuple {
+            item_0: inline_struct::SetMetadataArgsTupleMetadataTupleItem0 { code: 7 },
+            item_1: vec![
+                inline_struct::SetMetadataArgsTupleMetadataTupleItem1Inner {
+                    items: Some(inline_struct::SetMetadataArgsTupleMetadataTupleItem1Item {
+                        value: 8,
+                    }),
+                },
+                inline_struct::SetMetadataArgsTupleMetadataTupleItem1Inner { items: None },
+            ],
+        }),
+        optional_array_metadata: Some(inline_struct::SetMetadataArgsOptionalArrayMetadataOption {
+            value: vec![
+                inline_struct::SetMetadataArgsOptionalArrayMetadataValue { value: 9 },
+                inline_struct::SetMetadataArgsOptionalArrayMetadataValue { value: 10 },
+            ],
+        }),
+    };
+
+    let encoded = borsh::to_vec(&args).unwrap();
+    let decoded = inline_struct::instruction::SetMetadataArgs::try_from_slice(&encoded).unwrap();
+
+    assert_eq!(decoded, args);
 }

--- a/tests/proc-macro/tests/inline_struct.rs
+++ b/tests/proc-macro/tests/inline_struct.rs
@@ -26,6 +26,9 @@ fn check_protobuf_schema() {
     assert!(inline_struct::PROTOBUF_SCHEMA.contains("message DefinedOptional"));
     assert!(inline_struct::PROTOBUF_SCHEMA.contains("message DefinedTupleArrayItemTuple"));
     assert!(inline_struct::PROTOBUF_SCHEMA.contains("message DefinedNestedOption"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message FooOption"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message FooOption2"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message FirstAliasOption"));
 }
 
 #[test]
@@ -35,6 +38,23 @@ fn wrapped_defined_types_preserve_their_labels() {
     assert!(args.defined_optional.is_none());
     assert!(args.defined_tuple_array.is_empty());
     assert!(args.defined_nested.is_none());
+    assert!(args.first_alias.is_none());
+}
+
+#[test]
+fn generated_helpers_do_not_shadow_defined_types_or_forward_aliases() {
+    let nested_alias = inline_struct::FirstAliasOption { value: Some(7) };
+    let canonical_type = inline_struct::FooOption { code: 1 };
+    let generated_helper = inline_struct::FooOption2 { value: vec![2, 3] };
+
+    assert_eq!(
+        (
+            nested_alias.value,
+            canonical_type.code,
+            generated_helper.value
+        ),
+        (Some(7), 1, vec![2, 3]),
+    );
 }
 
 #[test]
@@ -104,14 +124,20 @@ fn nested_inline_structs_round_trip_borsh() {
 fn bare_tuple_deserializes_exact_borsh_wire() {
     use borsh::BorshDeserialize;
 
-    // The tuple begins with `code = 7`, rather than an Option discriminator.
+    // A fixed `None` option includes a tag plus zero padding matching its
+    // six-byte item. The tuple still begins with `code = 7`, not an option tag.
     let encoded = [
-        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, b'a',
-        b'a', b'a', 2, b'b', b'b', b'b', 7, 1, 8, 0, 0, 0, 0, 42,
-    ];
+        &[0u8][..],
+        &[0u8; 25][..],
+        &[0u8][..],
+        &[0u8; 6][..],
+        &[1, b'a', b'a', b'a', 2, b'b', b'b', b'b'][..],
+        &[7, 1, 8, 0, 0, 0, 0, 42][..],
+    ]
+    .concat();
     let decoded = inline_struct::instruction::SetMetadataArgs::try_from_slice(&encoded).unwrap();
 
-    assert_eq!(decoded, inline_struct::instruction::SetMetadataArgs {
+    let expected = inline_struct::instruction::SetMetadataArgs {
         metadata_name: inline_struct::SetMetadataArgsMetadataName {
             len: 0,
             value: vec![0; 25],
@@ -141,5 +167,8 @@ fn bare_tuple_deserializes_exact_borsh_wire() {
         optional_array_metadata: None,
         foo: None,
         foo_option: inline_struct::SetMetadataArgsFooOption2 { code: 42 },
-    });
+    };
+    let reencoded = borsh::to_vec(&expected).unwrap();
+
+    assert_eq!((decoded, reencoded), (expected, encoded));
 }

--- a/tests/proc-macro/tests/inline_struct.rs
+++ b/tests/proc-macro/tests/inline_struct.rs
@@ -23,6 +23,18 @@ fn check_protobuf_schema() {
         .contains("message SetMetadataArgsOptionalArrayMetadataOption"));
     assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsFooOption"));
     assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsFooOption2"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message DefinedOptional"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message DefinedTupleArrayItemTuple"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message DefinedNestedOption"));
+}
+
+#[test]
+fn wrapped_defined_types_preserve_their_labels() {
+    let args = inline_struct::instruction::UseDefinedAliasesArgs::default();
+
+    assert!(args.defined_optional.is_none());
+    assert!(args.defined_tuple_array.is_empty());
+    assert!(args.defined_nested.is_none());
 }
 
 #[test]

--- a/tests/proc-macro/tests/inline_struct.rs
+++ b/tests/proc-macro/tests/inline_struct.rs
@@ -1,0 +1,26 @@
+// Regression test for inline Codama structs.
+//
+// Pinocchio-style fixed strings can be represented as an inline struct such
+// as `[u8 length][N-byte UTF-8 buffer]`. The proc macro must materialize these
+// structs as protobuf messages, including when they are wrapped in Option.
+
+use vixen_test_utils::check_protobuf_format;
+use yellowstone_vixen_proc_macro::include_vixen_parser;
+
+include_vixen_parser!("../idls/inline_struct.json");
+
+#[test]
+fn check_protobuf_schema() {
+    check_protobuf_format(inline_struct::PROTOBUF_SCHEMA);
+
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsMetadataName"));
+    assert!(inline_struct::PROTOBUF_SCHEMA.contains("message SetMetadataArgsOptionalMetadata"));
+}
+
+#[test]
+fn inline_structs_are_generated_as_messages() {
+    let args = inline_struct::instruction::SetMetadataArgs::default();
+
+    assert_eq!(args.metadata_name.len, 0);
+    assert!(args.optional_metadata.is_none());
+}

--- a/tests/proc-macro/tests/inline_struct_collisions.rs
+++ b/tests/proc-macro/tests/inline_struct_collisions.rs
@@ -1,0 +1,40 @@
+use prost::Message;
+use prost_reflect::{DescriptorPool, DynamicMessage};
+use vixen_test_utils::check_protobuf_format;
+use yellowstone_vixen_proc_macro::include_vixen_parser;
+
+include_vixen_parser!("../idls/inline_struct_collisions.json");
+
+#[test]
+fn helpers_do_not_shadow_instruction_or_account_messages() {
+    let schema = inline_struct_collisions::PROTOBUF_SCHEMA;
+
+    check_protobuf_format(schema);
+
+    assert!(schema.contains("message FooArgs {\n  uint64 amount = 1;"));
+    assert!(schema.contains("message FooArgs2 {\n  uint32 code = 1;"));
+    assert!(schema.contains("message Bar {\n  uint32 account_value = 1;"));
+    assert!(schema.contains("message Bar2 {\n  uint32 code = 1;"));
+
+    let instructions = inline_struct_collisions::Instructions {
+        instruction: inline_struct_collisions::instruction::Instruction::Foo {
+            accounts: inline_struct_collisions::instruction::FooAccounts::default(),
+            args: inline_struct_collisions::instruction::FooArgs {
+                amount: 8_000_000_000,
+            },
+        },
+    };
+    let encoded = instructions.encode_to_vec();
+    let descriptor = protox_parse::parse("schema.proto", schema).expect("schema parse failed");
+    let mut pool = DescriptorPool::new();
+
+    pool.add_file_descriptor_proto(descriptor)
+        .expect("descriptor add failed");
+
+    let instructions_descriptor = pool
+        .get_message_by_name("inline_struct_collisions.Instructions")
+        .expect("Instructions message missing from schema");
+
+    DynamicMessage::decode(instructions_descriptor, encoded.as_slice())
+        .expect("schema-driven decode failed for generated instruction bytes");
+}

--- a/tests/proc-macro/tests/loopscale.rs
+++ b/tests/proc-macro/tests/loopscale.rs
@@ -15,7 +15,9 @@ include_vixen_parser!("../idls/loopscale.json");
 fn check_protobuf_schema() {
     check_protobuf_format(loopscale::PROTOBUF_SCHEMA);
 
-    insta::assert_snapshot!(loopscale::PROTOBUF_SCHEMA);
+    insta::assert_snapshot!(vixen_test_utils::normalize_protobuf_schema_for_snapshot(
+        loopscale::PROTOBUF_SCHEMA
+    ));
 }
 
 #[test]

--- a/tests/proc-macro/tests/metaplex.rs
+++ b/tests/proc-macro/tests/metaplex.rs
@@ -15,7 +15,9 @@ include_vixen_parser!("../idls/metaplex.json");
 fn check_protobuf_schema() {
     check_protobuf_format(token_metadata::PROTOBUF_SCHEMA);
 
-    insta::assert_snapshot!(token_metadata::PROTOBUF_SCHEMA);
+    insta::assert_snapshot!(vixen_test_utils::normalize_protobuf_schema_for_snapshot(
+        token_metadata::PROTOBUF_SCHEMA
+    ));
 }
 
 #[test]

--- a/tests/proc-macro/tests/snapshots/loopscale__check_protobuf_schema.snap
+++ b/tests/proc-macro/tests/snapshots/loopscale__check_protobuf_schema.snap
@@ -10,12 +10,12 @@ package loopscale;
 message PublicKey {
   bytes value = 1;
 }
-    
+
 message AddCollateralTimeLockArgs {
   CollateralTerms collateral_terms = 1;
   UpdateAssetDataParams update_asset_data_params = 2;
 }
-    
+
 message AssetData {
   PublicKey asset_identifier = 1;
   PublicKey quote_mint = 2;
@@ -28,41 +28,41 @@ message AssetData {
   bytes liquidation_threshold = 9;
   CollateralCaps collateral_caps = 10;
 }
-    
+
 message CapMonitor {
   bytes start_time1hr = 1;
   bytes start_time24hr = 2;
   bytes principal1hr = 3;
   bytes principal24hr = 4;
 }
-    
+
 message CollateralAllocationParam {
   PublicKey asset_identifier = 1;
   uint64 current_allocation_amount = 2;
 }
-    
+
 message CollateralCaps {
   bytes max_allocation_pct = 1;
   bytes current_allocation_amount = 2;
 }
-    
+
 message CollateralData {
   PublicKey asset_mint = 1;
   bytes amount = 2;
   uint32 asset_type = 3;
   PublicKey asset_identifier = 4;
 }
-    
+
 message CollateralTerms {
   PublicKey asset_identifier = 1;
   repeated uint64 terms = 2;
 }
-    
+
 message CollateralTermsIndices {
   uint32 collateral_index = 1;
   uint32 duration_index = 2;
 }
-    
+
 message CreateStrategyParams {
   PublicKey lender = 1;
   uint64 origination_cap = 2;
@@ -73,37 +73,37 @@ message CreateStrategyParams {
   bool originations_enabled = 7;
   optional ExternalYieldSourceArgs external_yield_source_args = 8;
 }
-    
+
 message Duration {
   bytes duration = 1;
   uint32 duration_type = 2;
 }
-    
+
 message ExactInParams {
   uint64 amount_in = 1;
   uint64 min_amount_out = 2;
 }
-    
+
 message ExactOutParams {
   uint64 amount_out = 1;
   uint64 max_amount_in = 2;
 }
-    
+
 message ExpectedLoanValues {
   uint64 expected_apy = 1;
   repeated uint32 expected_lqt = 2;
 }
-    
+
 message ExternalYieldAccounts {
   PublicKey external_yield_account = 1;
   PublicKey external_yield_vault = 2;
 }
-    
+
 message ExternalYieldSourceArgs {
   uint32 new_external_yield_source = 1;
   PublicKey external_yield_vault = 2;
 }
-    
+
 message Ledger {
   uint32 status = 1;
   PublicKey strategy = 2;
@@ -119,50 +119,50 @@ message Ledger {
   bytes end_time = 12;
   bytes apy = 13;
 }
-    
+
 message LiquidityParams {
   uint32 slippage_tolerance_bps = 1;
 }
-    
+
 message LpParamsExactIn {
   ExactInParams item_0 = 1;
 }
-    
+
 message LpParamsExactOut {
   ExactOutParams item_0 = 1;
 }
-    
+
 message ManageLiquidityParams {
   uint32 collateral_index = 1;
   bytes liquidity_amount = 2;
   TransferTypeParams transfer_params = 3;
   bytes asset_index_guidance = 4;
 }
-    
+
 message ManageRaydiumLiquidityParams {
   uint32 collateral_index = 1;
   bytes liquidity_amount = 2;
   TokenAmountsParams manage_params = 3;
   bytes asset_index_guidance = 4;
 }
-    
+
 message MultiCollateralTermsUpdateParams {
   uint64 apy = 1;
   repeated CollateralTermsIndices indices = 2;
 }
-    
+
 message ParsedPrincipalCaps {
   uint64 max1hr = 1;
   uint64 max24hr = 2;
   uint64 max_outstanding = 3;
 }
-    
+
 message PrincipalCaps {
   bytes max1hr = 1;
   bytes max24hr = 2;
   bytes max_outstanding = 3;
 }
-    
+
 message RewardInfo {
   uint32 reward_state = 1;
   uint64 open_time = 2;
@@ -176,44 +176,44 @@ message RewardInfo {
   PublicKey authority = 10;
   bytes reward_growth_global_x64 = 11;
 }
-    
+
 message TimelockUpdateParamsAddCollateral {
   AddCollateralTimeLockArgs item_0 = 1;
 }
-    
+
 message TimelockUpdateParamsUpdateLtv {
   UpdateAssetDataParams item_0 = 1;
 }
-    
+
 message TimelockUpdateParamsRemoveCollateral {
   CollateralTerms item_0 = 1;
 }
-    
+
 message TimelockUpdateParamsUpdateApy {
   CollateralTerms item_0 = 1;
 }
-    
+
 message TimelockUpdateParamsUpdateStrategy {
   UpdateStrategyParams item_0 = 1;
 }
-    
+
 message TimelockUpdateParamsUpdateVault {
   uint64 item_0 = 1;
 }
-    
+
 message TimelockUpdateParamsUpdateCaps {
   UpdateCapsParams item_0 = 1;
 }
-    
+
 message TimelockUpdateParamsUpdateCollateralAllocationPct {
   UpdateAssetDataParams item_0 = 1;
 }
-    
+
 message TokenAmountsParams {
   uint64 token_a_amount = 1;
   uint64 token_b_amount = 2;
 }
-    
+
 message TransferPositionParams {
   bytes liquidity_amount = 1;
   uint32 collateral_index = 2;
@@ -222,15 +222,15 @@ message TransferPositionParams {
   int32 tick_upper_index = 5;
   bytes asset_index_guidance = 6;
 }
-    
+
 message TransferTypeParamsLiquidity {
   LiquidityParams item_0 = 1;
 }
-    
+
 message TransferTypeParamsTokenAmounts {
   TokenAmountsParams item_0 = 1;
 }
-    
+
 message UpdateAssetDataParams {
   PublicKey asset_identifier = 1;
   optional PublicKey quote_mint = 2;
@@ -243,13 +243,13 @@ message UpdateAssetDataParams {
   optional uint64 max_collateral_allocation_pct = 9;
   optional bool remove = 10;
 }
-    
+
 message UpdateCapsParams {
   optional ParsedPrincipalCaps borrow_caps = 1;
   optional ParsedPrincipalCaps withdraw_caps = 2;
   optional ParsedPrincipalCaps supply_caps = 3;
 }
-    
+
 message UpdateStrategyParams {
   optional bool originations_enabled = 1;
   optional uint64 liquidity_buffer = 2;
@@ -260,7 +260,7 @@ message UpdateStrategyParams {
   optional PublicKey market_information = 7;
   optional ExternalYieldSourceArgs external_yield_source_args = 8;
 }
-    
+
 message VaultRewardsSchedule {
   PublicKey reward_mint = 1;
   bytes total_weighted_stake_supply = 2;
@@ -274,7 +274,7 @@ message VaultRewardsSchedule {
   bytes created_at = 10;
   repeated bytes duration_stake_weights = 11;
 }
-    
+
 message WhirlpoolRewardInfo {
   PublicKey mint = 1;
   PublicKey vault = 2;
@@ -282,29 +282,29 @@ message WhirlpoolRewardInfo {
   bytes emissions_per_second_x64 = 4;
   bytes growth_global_x64 = 5;
 }
-    
+
 message RaydiumAmmV3StatesPersonalPositionPositionRewardInfo {
   bytes growth_inside_last_x64 = 1;
   uint64 reward_amount_owed = 2;
 }
-    
+
 message WhirlpoolStatePositionPositionRewardInfo {
   bytes growth_inside_checkpoint = 1;
   uint64 amount_owed = 2;
 }
-    
+
 message LoanWeightMatrixInner {
   repeated bytes items = 1;
 }
-    
+
 message LoanLtvMatrixInner {
   repeated bytes items = 1;
 }
-    
+
 message LoanLqtMatrixInner {
   repeated bytes items = 1;
 }
-    
+
 message Loan {
   uint32 version = 1;
   uint32 bump = 2;
@@ -318,7 +318,7 @@ message Loan {
   repeated LoanLtvMatrixInner ltv_matrix = 10;
   repeated LoanLqtMatrixInner lqt_matrix = 11;
 }
-    
+
 message MarketInformation {
   PublicKey authority = 1;
   PublicKey delegate = 2;
@@ -329,7 +329,7 @@ message MarketInformation {
   PrincipalCaps supply_caps = 7;
   uint32 version = 8;
 }
-    
+
 message PersonalPositionState {
   bytes bump = 1;
   PublicKey nft_mint = 2;
@@ -345,7 +345,7 @@ message PersonalPositionState {
   uint64 recent_epoch = 12;
   repeated uint64 padding = 13;
 }
-    
+
 message PoolState {
   bytes bump = 1;
   PublicKey amm_config = 2;
@@ -386,7 +386,7 @@ message PoolState {
   repeated uint64 padding1 = 37;
   repeated uint64 padding2 = 38;
 }
-    
+
 message Position {
   PublicKey whirlpool = 1;
   PublicKey position_mint = 2;
@@ -399,7 +399,7 @@ message Position {
   uint64 fee_owed_b = 9;
   repeated WhirlpoolStatePositionPositionRewardInfo reward_infos = 10;
 }
-    
+
 message ProtocolPositionState {
   uint32 bump = 1;
   PublicKey pool_id = 2;
@@ -414,11 +414,11 @@ message ProtocolPositionState {
   uint64 recent_epoch = 11;
   repeated uint64 padding = 12;
 }
-    
+
 message StrategyCollateralMapInner {
   repeated bytes items = 1;
 }
-    
+
 message Strategy {
   uint32 version = 1;
   PublicKey nonce = 2;
@@ -450,14 +450,14 @@ message Strategy {
   CapMonitor withdraw_monitor = 28;
   CapMonitor borrow_monitor = 29;
 }
-    
+
 message Timelock {
   PublicKey vault = 1;
   int64 init_timestamp = 2;
   int64 execution_delay = 3;
   TimelockUpdateParams params = 4;
 }
-    
+
 message UserRewardsInfo {
   PublicKey vault_address = 1;
   uint32 bump = 2;
@@ -470,7 +470,7 @@ message UserRewardsInfo {
   repeated bytes pending_rewards = 9;
   repeated bytes last_reward_index_update_time = 10;
 }
-    
+
 message Vault {
   PublicKey manager = 1;
   PublicKey nonce = 2;
@@ -482,13 +482,13 @@ message Vault {
   uint32 deposits_enabled = 8;
   bytes max_early_unstake_fee = 9;
 }
-    
+
 message VaultRewardsInfo {
   PublicKey vault_address = 1;
   uint32 bump = 2;
   repeated VaultRewardsSchedule schedules = 3;
 }
-    
+
 message VaultStake {
   PublicKey vault = 1;
   PublicKey nonce = 2;
@@ -501,7 +501,7 @@ message VaultStake {
   bytes unstake_time = 9;
   bytes unstake_fee_applied = 10;
 }
-    
+
 message Whirlpool {
   PublicKey whirlpools_config = 1;
   bytes whirlpool_bump = 2;
@@ -523,7 +523,7 @@ message Whirlpool {
   uint64 reward_last_updated_timestamp = 18;
   repeated WhirlpoolRewardInfo reward_infos = 19;
 }
-    
+
 message BorrowPrincipalAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -541,7 +541,7 @@ message BorrowPrincipalAccounts {
   PublicKey program = 14;
   repeated PublicKey remaining_accounts = 15;
 }
-    
+
 message BorrowPrincipalArgs {
   uint64 amount = 1;
   bytes asset_index_guidance = 2;
@@ -549,12 +549,12 @@ message BorrowPrincipalArgs {
   ExpectedLoanValues expected_loan_values = 4;
   bool skip_sol_unwrap = 5;
 }
-    
+
 message BorrowPrincipal {
   BorrowPrincipalAccounts accounts = 1;
   BorrowPrincipalArgs args = 2;
 }
-    
+
 message CancelTimelockAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -566,15 +566,15 @@ message CancelTimelockAccounts {
   PublicKey program = 8;
   repeated PublicKey remaining_accounts = 9;
 }
-    
+
 message CancelTimelockArgs {
 }
-    
+
 message CancelTimelock {
   CancelTimelockAccounts accounts = 1;
   CancelTimelockArgs args = 2;
 }
-    
+
 message ClaimVaultFeeAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -592,16 +592,16 @@ message ClaimVaultFeeAccounts {
   PublicKey program = 14;
   repeated PublicKey remaining_accounts = 15;
 }
-    
+
 message ClaimVaultFeeArgs {
   uint64 amount = 1;
 }
-    
+
 message ClaimVaultFee {
   ClaimVaultFeeAccounts accounts = 1;
   ClaimVaultFeeArgs args = 2;
 }
-    
+
 message ClaimVaultRewardsAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -616,16 +616,16 @@ message ClaimVaultRewardsAccounts {
   PublicKey program = 11;
   repeated PublicKey remaining_accounts = 12;
 }
-    
+
 message ClaimVaultRewardsArgs {
   repeated PublicKey mints = 1;
 }
-    
+
 message ClaimVaultRewards {
   ClaimVaultRewardsAccounts accounts = 1;
   ClaimVaultRewardsArgs args = 2;
 }
-    
+
 message CloseLoanAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -636,15 +636,15 @@ message CloseLoanAccounts {
   PublicKey program = 7;
   repeated PublicKey remaining_accounts = 8;
 }
-    
+
 message CloseLoanArgs {
 }
-    
+
 message CloseLoan {
   CloseLoanAccounts accounts = 1;
   CloseLoanArgs args = 2;
 }
-    
+
 message CloseStrategyAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -658,15 +658,15 @@ message CloseStrategyAccounts {
   PublicKey program = 10;
   repeated PublicKey remaining_accounts = 11;
 }
-    
+
 message CloseStrategyArgs {
 }
-    
+
 message CloseStrategy {
   CloseStrategyAccounts accounts = 1;
   CloseStrategyArgs args = 2;
 }
-    
+
 message CreateLoanAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -677,33 +677,33 @@ message CreateLoanAccounts {
   PublicKey program = 7;
   repeated PublicKey remaining_accounts = 8;
 }
-    
+
 message CreateLoanArgs {
   uint64 nonce = 1;
 }
-    
+
 message CreateLoan {
   CreateLoanAccounts accounts = 1;
   CreateLoanArgs args = 2;
 }
-    
+
 message CreateMarketInformationAccounts {
   PublicKey bs_auth = 1;
   PublicKey market_information = 2;
   PublicKey system_program = 3;
   repeated PublicKey remaining_accounts = 4;
 }
-    
+
 message CreateMarketInformationArgs {
   PublicKey principal_mint = 1;
   PublicKey authority = 2;
 }
-    
+
 message CreateMarketInformation {
   CreateMarketInformationAccounts accounts = 1;
   CreateMarketInformationArgs args = 2;
 }
-    
+
 message CreateRewardsScheduleAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -721,7 +721,7 @@ message CreateRewardsScheduleAccounts {
   PublicKey program = 14;
   repeated PublicKey remaining_accounts = 15;
 }
-    
+
 message CreateRewardsScheduleArgs {
   bytes total_weighted_stake_supply = 1;
   bytes reward_start_time = 2;
@@ -729,12 +729,12 @@ message CreateRewardsScheduleArgs {
   repeated bytes duration_stake_weights = 4;
   uint64 amount_to_transfer = 5;
 }
-    
+
 message CreateRewardsSchedule {
   CreateRewardsScheduleAccounts accounts = 1;
   CreateRewardsScheduleArgs args = 2;
 }
-    
+
 message CreateStrategyAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -747,16 +747,16 @@ message CreateStrategyAccounts {
   PublicKey program = 9;
   repeated PublicKey remaining_accounts = 10;
 }
-    
+
 message CreateStrategyArgs {
   CreateStrategyParams params = 1;
 }
-    
+
 message CreateStrategy {
   CreateStrategyAccounts accounts = 1;
   CreateStrategyArgs args = 2;
 }
-    
+
 message CreateTimelockAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -770,16 +770,16 @@ message CreateTimelockAccounts {
   PublicKey program = 10;
   repeated PublicKey remaining_accounts = 11;
 }
-    
+
 message CreateTimelockArgs {
   TimelockUpdateParams params = 1;
 }
-    
+
 message CreateTimelock {
   CreateTimelockAccounts accounts = 1;
   CreateTimelockArgs args = 2;
 }
-    
+
 message CreateVaultAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -795,7 +795,7 @@ message CreateVaultAccounts {
   PublicKey program = 12;
   repeated PublicKey remaining_accounts = 13;
 }
-    
+
 message CreateVaultArgs {
   string token_name = 1;
   string token_symbol = 2;
@@ -803,12 +803,12 @@ message CreateVaultArgs {
   PublicKey manager = 4;
   CreateStrategyParams create_strategy_params = 5;
 }
-    
+
 message CreateVault {
   CreateVaultAccounts accounts = 1;
   CreateVaultArgs args = 2;
 }
-    
+
 message DepositCollateralAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -825,19 +825,19 @@ message DepositCollateralAccounts {
   PublicKey program = 13;
   repeated PublicKey remaining_accounts = 14;
 }
-    
+
 message DepositCollateralArgs {
   uint64 amount = 1;
   uint32 asset_type = 2;
   PublicKey asset_identifier = 3;
   bytes asset_index_guidance = 4;
 }
-    
+
 message DepositCollateral {
   DepositCollateralAccounts accounts = 1;
   DepositCollateralArgs args = 2;
 }
-    
+
 message DepositStrategyAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -854,16 +854,16 @@ message DepositStrategyAccounts {
   PublicKey program = 13;
   repeated PublicKey remaining_accounts = 14;
 }
-    
+
 message DepositStrategyArgs {
   uint64 amount = 1;
 }
-    
+
 message DepositStrategy {
   DepositStrategyAccounts accounts = 1;
   DepositStrategyArgs args = 2;
 }
-    
+
 message DepositUserVaultAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -884,16 +884,16 @@ message DepositUserVaultAccounts {
   PublicKey program = 17;
   repeated PublicKey remaining_accounts = 18;
 }
-    
+
 message DepositUserVaultArgs {
   LpParams params = 1;
 }
-    
+
 message DepositUserVault {
   DepositUserVaultAccounts accounts = 1;
   DepositUserVaultArgs args = 2;
 }
-    
+
 message ExecuteTimelockAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -910,15 +910,15 @@ message ExecuteTimelockAccounts {
   PublicKey program = 13;
   repeated PublicKey remaining_accounts = 14;
 }
-    
+
 message ExecuteTimelockArgs {
 }
-    
+
 message ExecuteTimelock {
   ExecuteTimelockAccounts accounts = 1;
   ExecuteTimelockArgs args = 2;
 }
-    
+
 message LiquidateLedgerAccounts {
   PublicKey payer = 1;
   PublicKey liquidator = 2;
@@ -937,18 +937,18 @@ message LiquidateLedgerAccounts {
   PublicKey program = 15;
   repeated PublicKey remaining_accounts = 16;
 }
-    
+
 message LiquidateLedgerArgs {
   uint32 ledger_index = 1;
   bool unwrap_sol = 2;
   bytes asset_index_guidance = 3;
 }
-    
+
 message LiquidateLedger {
   LiquidateLedgerAccounts accounts = 1;
   LiquidateLedgerArgs args = 2;
 }
-    
+
 message LockLoanAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -958,16 +958,16 @@ message LockLoanAccounts {
   PublicKey system_program = 6;
   repeated PublicKey remaining_accounts = 7;
 }
-    
+
 message LockLoanArgs {
   uint32 unlock_idx = 1;
 }
-    
+
 message LockLoan {
   LockLoanAccounts accounts = 1;
   LockLoanArgs args = 2;
 }
-    
+
 message ManageCollateralClaimOrcaFeeAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -996,16 +996,16 @@ message ManageCollateralClaimOrcaFeeAccounts {
   PublicKey program = 25;
   repeated PublicKey remaining_accounts = 26;
 }
-    
+
 message ManageCollateralClaimOrcaFeeArgs {
   bool close_ta = 1;
 }
-    
+
 message ManageCollateralClaimOrcaFee {
   ManageCollateralClaimOrcaFeeAccounts accounts = 1;
   ManageCollateralClaimOrcaFeeArgs args = 2;
 }
-    
+
 message ManageCollateralDecreaseRaydiumLiquidityAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1035,16 +1035,16 @@ message ManageCollateralDecreaseRaydiumLiquidityAccounts {
   PublicKey program = 26;
   repeated PublicKey remaining_accounts = 27;
 }
-    
+
 message ManageCollateralDecreaseRaydiumLiquidityArgs {
   ManageRaydiumLiquidityParams params = 1;
 }
-    
+
 message ManageCollateralDecreaseRaydiumLiquidity {
   ManageCollateralDecreaseRaydiumLiquidityAccounts accounts = 1;
   ManageCollateralDecreaseRaydiumLiquidityArgs args = 2;
 }
-    
+
 message ManageCollateralIncreaseOrcaLiquidityAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1073,16 +1073,16 @@ message ManageCollateralIncreaseOrcaLiquidityAccounts {
   PublicKey program = 25;
   repeated PublicKey remaining_accounts = 26;
 }
-    
+
 message ManageCollateralIncreaseOrcaLiquidityArgs {
   ManageLiquidityParams params = 1;
 }
-    
+
 message ManageCollateralIncreaseOrcaLiquidity {
   ManageCollateralIncreaseOrcaLiquidityAccounts accounts = 1;
   ManageCollateralIncreaseOrcaLiquidityArgs args = 2;
 }
-    
+
 message ManageCollateralIncreaseRaydiumLiquidityAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1112,16 +1112,16 @@ message ManageCollateralIncreaseRaydiumLiquidityAccounts {
   PublicKey program = 26;
   repeated PublicKey remaining_accounts = 27;
 }
-    
+
 message ManageCollateralIncreaseRaydiumLiquidityArgs {
   ManageRaydiumLiquidityParams params = 1;
 }
-    
+
 message ManageCollateralIncreaseRaydiumLiquidity {
   ManageCollateralIncreaseRaydiumLiquidityAccounts accounts = 1;
   ManageCollateralIncreaseRaydiumLiquidityArgs args = 2;
 }
-    
+
 message ManageCollateralTransferOrcaPositionAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1157,16 +1157,16 @@ message ManageCollateralTransferOrcaPositionAccounts {
   PublicKey program = 32;
   repeated PublicKey remaining_accounts = 33;
 }
-    
+
 message ManageCollateralTransferOrcaPositionArgs {
   TransferPositionParams params = 1;
 }
-    
+
 message ManageCollateralTransferOrcaPosition {
   ManageCollateralTransferOrcaPositionAccounts accounts = 1;
   ManageCollateralTransferOrcaPositionArgs args = 2;
 }
-    
+
 message ManageCollateralTransferRaydiumPositionAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1202,16 +1202,16 @@ message ManageCollateralTransferRaydiumPositionAccounts {
   PublicKey memo_program = 32;
   repeated PublicKey remaining_accounts = 33;
 }
-    
+
 message ManageCollateralTransferRaydiumPositionArgs {
   TransferPositionParams params = 1;
 }
-    
+
 message ManageCollateralTransferRaydiumPosition {
   ManageCollateralTransferRaydiumPositionAccounts accounts = 1;
   ManageCollateralTransferRaydiumPositionArgs args = 2;
 }
-    
+
 message ManageCollateralWithdrawOrcaLiquidityAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1240,16 +1240,16 @@ message ManageCollateralWithdrawOrcaLiquidityAccounts {
   PublicKey program = 25;
   repeated PublicKey remaining_accounts = 26;
 }
-    
+
 message ManageCollateralWithdrawOrcaLiquidityArgs {
   ManageLiquidityParams params = 1;
 }
-    
+
 message ManageCollateralWithdrawOrcaLiquidity {
   ManageCollateralWithdrawOrcaLiquidityAccounts accounts = 1;
   ManageCollateralWithdrawOrcaLiquidityArgs args = 2;
 }
-    
+
 message MigrateMarketInfoAllocationAccounts {
   PublicKey bs_auth = 1;
   PublicKey market_info = 2;
@@ -1257,16 +1257,16 @@ message MigrateMarketInfoAllocationAccounts {
   PublicKey program = 4;
   repeated PublicKey remaining_accounts = 5;
 }
-    
+
 message MigrateMarketInfoAllocationArgs {
   repeated CollateralAllocationParam allocations = 1;
 }
-    
+
 message MigrateMarketInfoAllocation {
   MigrateMarketInfoAllocationAccounts accounts = 1;
   MigrateMarketInfoAllocationArgs args = 2;
 }
-    
+
 message RefinanceLedgerAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1285,18 +1285,18 @@ message RefinanceLedgerAccounts {
   PublicKey program = 15;
   repeated PublicKey remaining_accounts = 16;
 }
-    
+
 message RefinanceLedgerArgs {
   uint32 ledger_index = 1;
   uint32 duration_index = 2;
   bytes asset_index_guidance = 3;
 }
-    
+
 message RefinanceLedger {
   RefinanceLedgerAccounts accounts = 1;
   RefinanceLedgerArgs args = 2;
 }
-    
+
 message RepayPrincipalAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1314,18 +1314,18 @@ message RepayPrincipalAccounts {
   PublicKey program = 14;
   repeated PublicKey remaining_accounts = 15;
 }
-    
+
 message RepayPrincipalArgs {
   uint64 amount = 1;
   uint32 ledger_index = 2;
   bool repay_all = 3;
 }
-    
+
 message RepayPrincipal {
   RepayPrincipalAccounts accounts = 1;
   RepayPrincipalArgs args = 2;
 }
-    
+
 message SellLedgerAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1347,18 +1347,18 @@ message SellLedgerAccounts {
   PublicKey program = 18;
   repeated PublicKey remaining_accounts = 19;
 }
-    
+
 message SellLedgerArgs {
   uint32 ledger_index = 1;
   uint64 expected_sale_price = 2;
   bytes asset_index_guidance = 3;
 }
-    
+
 message SellLedger {
   SellLedgerAccounts accounts = 1;
   SellLedgerArgs args = 2;
 }
-    
+
 message StakeUserVaultLpAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1378,7 +1378,7 @@ message StakeUserVaultLpAccounts {
   PublicKey program = 16;
   repeated PublicKey remaining_accounts = 17;
 }
-    
+
 message StakeUserVaultLpArgs {
   uint64 amount = 1;
   uint64 principal_amount = 2;
@@ -1387,12 +1387,12 @@ message StakeUserVaultLpArgs {
   uint32 duration_type = 5;
   uint32 action_type = 6;
 }
-    
+
 message StakeUserVaultLp {
   StakeUserVaultLpAccounts accounts = 1;
   StakeUserVaultLpArgs args = 2;
 }
-    
+
 message UnlockLoanAccounts {
   PublicKey borrower = 1;
   PublicKey loan = 2;
@@ -1401,16 +1401,16 @@ message UnlockLoanAccounts {
   PublicKey system_program = 5;
   repeated PublicKey remaining_accounts = 6;
 }
-    
+
 message UnlockLoanArgs {
   bytes asset_index_guidance = 1;
 }
-    
+
 message UnlockLoan {
   UnlockLoanAccounts accounts = 1;
   UnlockLoanArgs args = 2;
 }
-    
+
 message UnstakeUserVaultLpAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1429,37 +1429,37 @@ message UnstakeUserVaultLpAccounts {
   PublicKey program = 15;
   repeated PublicKey remaining_accounts = 16;
 }
-    
+
 message UnstakeUserVaultLpArgs {
   uint32 action_type = 1;
   uint64 principal_amount = 2;
 }
-    
+
 message UnstakeUserVaultLp {
   UnstakeUserVaultLpAccounts accounts = 1;
   UnstakeUserVaultLpArgs args = 2;
 }
-    
+
 message UpdateMarketInformationAccounts {
   PublicKey authority = 1;
   PublicKey market_information = 2;
   repeated PublicKey remaining_accounts = 3;
 }
-    
+
 message UpdateMarketInformationArgsAssetUpdateParamsOption {
   repeated UpdateAssetDataParams value = 1;
 }
-    
+
 message UpdateMarketInformationArgs {
   optional UpdateMarketInformationArgsAssetUpdateParamsOption asset_update_params = 1;
   optional UpdateCapsParams update_cap_params = 2;
 }
-    
+
 message UpdateMarketInformation {
   UpdateMarketInformationAccounts accounts = 1;
   UpdateMarketInformationArgs args = 2;
 }
-    
+
 message UpdateRewardsScheduleAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1477,18 +1477,18 @@ message UpdateRewardsScheduleAccounts {
   PublicKey program = 14;
   repeated PublicKey remaining_accounts = 15;
 }
-    
+
 message UpdateRewardsScheduleArgs {
   uint64 amount_to_transfer = 1;
   optional uint64 extend_end_time = 2;
   uint32 schedule_index = 3;
 }
-    
+
 message UpdateRewardsSchedule {
   UpdateRewardsScheduleAccounts accounts = 1;
   UpdateRewardsScheduleArgs args = 2;
 }
-    
+
 message UpdateStrategyAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1503,17 +1503,17 @@ message UpdateStrategyAccounts {
   PublicKey program = 11;
   repeated PublicKey remaining_accounts = 12;
 }
-    
+
 message UpdateStrategyArgs {
   repeated MultiCollateralTermsUpdateParams collateral_terms = 1;
   optional UpdateStrategyParams params = 2;
 }
-    
+
 message UpdateStrategy {
   UpdateStrategyAccounts accounts = 1;
   UpdateStrategyArgs args = 2;
 }
-    
+
 message UpdateVaultAccounts {
   PublicKey bs_auth = 1;
   PublicKey manager = 2;
@@ -1524,36 +1524,36 @@ message UpdateVaultAccounts {
   PublicKey system_program = 7;
   repeated PublicKey remaining_accounts = 8;
 }
-    
+
 message UpdateVaultArgs {
   bool deposits_enabled = 1;
   bool init_vault_rewards_info = 2;
 }
-    
+
 message UpdateVault {
   UpdateVaultAccounts accounts = 1;
   UpdateVaultArgs args = 2;
 }
-    
+
 message UpdateWeightMatrixAccounts {
   PublicKey bs_auth = 1;
   PublicKey borrower = 2;
   PublicKey loan = 3;
   repeated PublicKey remaining_accounts = 4;
 }
-    
+
 message UpdateWeightMatrixArgs {
   uint32 collateral_index = 1;
   repeated uint32 weight_matrix = 2;
   ExpectedLoanValues expected_loan_values = 3;
   bytes asset_index_guidance = 4;
 }
-    
+
 message UpdateWeightMatrix {
   UpdateWeightMatrixAccounts accounts = 1;
   UpdateWeightMatrixArgs args = 2;
 }
-    
+
 message WithdrawCollateralAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1569,7 +1569,7 @@ message WithdrawCollateralAccounts {
   PublicKey program = 12;
   repeated PublicKey remaining_accounts = 13;
 }
-    
+
 message WithdrawCollateralArgs {
   uint64 amount = 1;
   uint32 collateral_index = 2;
@@ -1577,12 +1577,12 @@ message WithdrawCollateralArgs {
   ExpectedLoanValues expected_loan_values = 4;
   bool close_if_eligible = 5;
 }
-    
+
 message WithdrawCollateral {
   WithdrawCollateralAccounts accounts = 1;
   WithdrawCollateralArgs args = 2;
 }
-    
+
 message WithdrawStrategyAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1599,17 +1599,17 @@ message WithdrawStrategyAccounts {
   PublicKey program = 13;
   repeated PublicKey remaining_accounts = 14;
 }
-    
+
 message WithdrawStrategyArgs {
   uint64 amount = 1;
   bool withdraw_all = 2;
 }
-    
+
 message WithdrawStrategy {
   WithdrawStrategyAccounts accounts = 1;
   WithdrawStrategyArgs args = 2;
 }
-    
+
 message WithdrawUserVaultAccounts {
   PublicKey bs_auth = 1;
   PublicKey payer = 2;
@@ -1630,16 +1630,16 @@ message WithdrawUserVaultAccounts {
   PublicKey program = 17;
   repeated PublicKey remaining_accounts = 18;
 }
-    
+
 message WithdrawUserVaultArgs {
   LpParams params = 1;
 }
-    
+
 message WithdrawUserVault {
   WithdrawUserVaultAccounts accounts = 1;
   WithdrawUserVaultArgs args = 2;
 }
-    
+
 message LoopscaleAccount {
   oneof account {
     Loan loan = 1;

--- a/tests/proc-macro/tests/snapshots/loopscale__check_protobuf_schema.snap
+++ b/tests/proc-macro/tests/snapshots/loopscale__check_protobuf_schema.snap
@@ -1446,8 +1446,12 @@ message UpdateMarketInformationAccounts {
   repeated PublicKey remaining_accounts = 3;
 }
     
+message UpdateMarketInformationArgsAssetUpdateParamsOption {
+  repeated UpdateAssetDataParams value = 1;
+}
+    
 message UpdateMarketInformationArgs {
-  optional UpdateAssetDataParams asset_update_params = 1;
+  optional UpdateMarketInformationArgsAssetUpdateParamsOption asset_update_params = 1;
   optional UpdateCapsParams update_cap_params = 2;
 }
     

--- a/tests/proc-macro/tests/snapshots/metaplex__check_protobuf_schema.snap
+++ b/tests/proc-macro/tests/snapshots/metaplex__check_protobuf_schema.snap
@@ -10,52 +10,52 @@ package token_metadata;
 message PublicKey {
   bytes value = 1;
 }
-    
+
 message SetCollectionSizeArgs {
   uint64 size = 1;
 }
-    
+
 message CreateMasterEditionArgs {
   optional uint64 max_supply = 1;
 }
-    
+
 message MintNewEditionFromMasterEditionViaTokenArgs {
   uint64 edition = 1;
 }
-    
+
 message TransferOutOfEscrowArgs {
   uint64 amount = 1;
 }
-    
+
 message CreateMetadataAccountArgsV3 {
   DataV2 data = 1;
   bool is_mutable = 2;
   optional CollectionDetails collection_details = 3;
 }
-    
+
 message UpdateMetadataAccountArgsV2 {
   optional DataV2 data = 1;
   optional PublicKey update_authority = 2;
   optional bool primary_sale_happened = 3;
   optional bool is_mutable = 4;
 }
-    
+
 message ApproveUseAuthorityArgs {
   uint64 number_of_uses = 1;
 }
-    
+
 message UtilizeArgs {
   uint64 number_of_uses = 1;
 }
-    
+
 message AuthorizationData {
   Payload payload = 1;
 }
-    
+
 message AssetDataCreatorsOption {
   repeated Creator value = 1;
 }
-    
+
 message AssetData {
   string name = 1;
   string symbol = 2;
@@ -70,22 +70,22 @@ message AssetData {
   optional CollectionDetails collection_details = 11;
   optional PublicKey rule_set = 12;
 }
-    
+
 message Collection {
   bool verified = 1;
   PublicKey key = 2;
 }
-    
+
 message Creator {
   PublicKey address = 1;
   bool verified = 2;
   uint32 share = 3;
 }
-    
+
 message DataCreatorsOption {
   repeated Creator value = 1;
 }
-    
+
 message Data {
   string name = 1;
   string symbol = 2;
@@ -93,11 +93,11 @@ message Data {
   uint32 seller_fee_basis_points = 4;
   optional DataCreatorsOption creators = 5;
 }
-    
+
 message DataV2CreatorsOption {
   repeated Creator value = 1;
 }
-    
+
 message DataV2 {
   string name = 1;
   string symbol = 2;
@@ -107,191 +107,191 @@ message DataV2 {
   optional Collection collection = 6;
   optional Uses uses = 7;
 }
-    
+
 message Reservation {
   PublicKey address = 1;
   uint64 spots_remaining = 2;
   uint64 total_spots = 3;
 }
-    
+
 message ReservationV1 {
   PublicKey address = 1;
   uint32 spots_remaining = 2;
   uint32 total_spots = 3;
 }
-    
+
 message SeedsVec {
   repeated bytes seeds = 1;
 }
-    
+
 message ProofInfo {
   repeated bytes proof = 1;
 }
-    
+
 message Payload {
   bytes map = 1;
 }
-    
+
 message Uses {
   UseMethod use_method = 1;
   uint64 remaining = 2;
   uint64 total = 3;
 }
-    
+
 message BurnArgsV1 {
   uint64 amount = 1;
 }
-    
+
 message DelegateArgsCollectionV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message DelegateArgsSaleV1 {
   uint64 amount = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message DelegateArgsTransferV1 {
   uint64 amount = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message DelegateArgsDataV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message DelegateArgsUtilityV1 {
   uint64 amount = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message DelegateArgsStakingV1 {
   uint64 amount = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message DelegateArgsStandardV1 {
   uint64 amount = 1;
 }
-    
+
 message DelegateArgsLockedTransferV1 {
   uint64 amount = 1;
   PublicKey locked_address = 2;
   optional AuthorizationData authorization_data = 3;
 }
-    
+
 message DelegateArgsProgrammableConfigV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message DelegateArgsAuthorityItemV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message DelegateArgsDataItemV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message DelegateArgsCollectionItemV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message DelegateArgsProgrammableConfigItemV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message DelegateArgsPrintDelegateV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message RevokeArgsCollectionV1 {
 }
-    
+
 message RevokeArgsSaleV1 {
 }
-    
+
 message RevokeArgsTransferV1 {
 }
-    
+
 message RevokeArgsDataV1 {
 }
-    
+
 message RevokeArgsUtilityV1 {
 }
-    
+
 message RevokeArgsStakingV1 {
 }
-    
+
 message RevokeArgsStandardV1 {
 }
-    
+
 message RevokeArgsLockedTransferV1 {
 }
-    
+
 message RevokeArgsProgrammableConfigV1 {
 }
-    
+
 message RevokeArgsMigrationV1 {
 }
-    
+
 message RevokeArgsAuthorityItemV1 {
 }
-    
+
 message RevokeArgsDataItemV1 {
 }
-    
+
 message RevokeArgsCollectionItemV1 {
 }
-    
+
 message RevokeArgsProgrammableConfigItemV1 {
 }
-    
+
 message RevokeArgsPrintDelegateV1 {
 }
-    
+
 message MetadataDelegateRoleAuthorityItem {
 }
-    
+
 message MetadataDelegateRoleCollection {
 }
-    
+
 message MetadataDelegateRoleUse {
 }
-    
+
 message MetadataDelegateRoleData {
 }
-    
+
 message MetadataDelegateRoleProgrammableConfig {
 }
-    
+
 message MetadataDelegateRoleDataItem {
 }
-    
+
 message MetadataDelegateRoleCollectionItem {
 }
-    
+
 message MetadataDelegateRoleProgrammableConfigItem {
 }
-    
+
 message HolderDelegateRolePrintDelegate {
 }
-    
+
 message CreateArgsV1 {
   AssetData asset_data = 1;
   optional uint32 decimals = 2;
   optional PrintSupply print_supply = 3;
 }
-    
+
 message MintArgsV1 {
   uint64 amount = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message TransferArgsV1 {
   uint64 amount = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message UpdateArgsV1 {
   optional PublicKey new_update_authority = 1;
   optional Data data = 2;
@@ -303,7 +303,7 @@ message UpdateArgsV1 {
   RuleSetToggle rule_set = 8;
   optional AuthorizationData authorization_data = 9;
 }
-    
+
 message UpdateArgsAsUpdateAuthorityV2 {
   optional PublicKey new_update_authority = 1;
   optional Data data = 2;
@@ -316,7 +316,7 @@ message UpdateArgsAsUpdateAuthorityV2 {
   optional TokenStandard token_standard = 9;
   optional AuthorizationData authorization_data = 10;
 }
-    
+
 message UpdateArgsAsAuthorityItemDelegateV2 {
   optional PublicKey new_update_authority = 1;
   optional bool primary_sale_happened = 2;
@@ -324,307 +324,307 @@ message UpdateArgsAsAuthorityItemDelegateV2 {
   optional TokenStandard token_standard = 4;
   optional AuthorizationData authorization_data = 5;
 }
-    
+
 message UpdateArgsAsCollectionDelegateV2 {
   CollectionToggle collection = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message UpdateArgsAsDataDelegateV2 {
   optional Data data = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message UpdateArgsAsProgrammableConfigDelegateV2 {
   RuleSetToggle rule_set = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message UpdateArgsAsDataItemDelegateV2 {
   optional Data data = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message UpdateArgsAsCollectionItemDelegateV2 {
   CollectionToggle collection = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message UpdateArgsAsProgrammableConfigItemDelegateV2 {
   RuleSetToggle rule_set = 1;
   optional AuthorizationData authorization_data = 2;
 }
-    
+
 message CollectionToggleNone {
 }
-    
+
 message CollectionToggleClear {
 }
-    
+
 message CollectionToggleSet {
   Collection item_0 = 1;
 }
-    
+
 message UsesToggleNone {
 }
-    
+
 message UsesToggleClear {
 }
-    
+
 message UsesToggleSet {
   Uses item_0 = 1;
 }
-    
+
 message CollectionDetailsToggleNone {
 }
-    
+
 message CollectionDetailsToggleClear {
 }
-    
+
 message CollectionDetailsToggleSet {
   CollectionDetails item_0 = 1;
 }
-    
+
 message RuleSetToggleNone {
 }
-    
+
 message RuleSetToggleClear {
 }
-    
+
 message RuleSetToggleSet {
   PublicKey item_0 = 1;
 }
-    
+
 message PrintArgsV1 {
   uint64 edition = 1;
 }
-    
+
 message PrintArgsV2 {
   uint64 edition = 1;
 }
-    
+
 message LockArgsV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message UnlockArgsV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message UseArgsV1 {
   optional AuthorizationData authorization_data = 1;
 }
-    
+
 message VerificationArgsCreatorV1 {
 }
-    
+
 message VerificationArgsCollectionV1 {
 }
-    
+
 message TokenStandardNonFungible {
 }
-    
+
 message TokenStandardFungibleAsset {
 }
-    
+
 message TokenStandardFungible {
 }
-    
+
 message TokenStandardNonFungibleEdition {
 }
-    
+
 message TokenStandardProgrammableNonFungible {
 }
-    
+
 message TokenStandardProgrammableNonFungibleEdition {
 }
-    
+
 message KeyUninitialized {
 }
-    
+
 message KeyEditionV1 {
 }
-    
+
 message KeyMasterEditionV1 {
 }
-    
+
 message KeyReservationListV1 {
 }
-    
+
 message KeyMetadataV1 {
 }
-    
+
 message KeyReservationListV2 {
 }
-    
+
 message KeyMasterEditionV2 {
 }
-    
+
 message KeyEditionMarker {
 }
-    
+
 message KeyUseAuthorityRecord {
 }
-    
+
 message KeyCollectionAuthorityRecord {
 }
-    
+
 message KeyTokenOwnedEscrow {
 }
-    
+
 message KeyTokenRecord {
 }
-    
+
 message KeyMetadataDelegate {
 }
-    
+
 message KeyEditionMarkerV2 {
 }
-    
+
 message KeyHolderDelegate {
 }
-    
+
 message CollectionDetailsV1 {
   uint64 size = 1;
 }
-    
+
 message CollectionDetailsV2 {
   bytes padding = 1;
 }
-    
+
 message EscrowAuthorityTokenOwner {
 }
-    
+
 message EscrowAuthorityCreator {
   PublicKey item_0 = 1;
 }
-    
+
 message PrintSupplyZero {
 }
-    
+
 message PrintSupplyLimited {
   uint64 item_0 = 1;
 }
-    
+
 message PrintSupplyUnlimited {
 }
-    
+
 message ProgrammableConfigV1 {
   optional PublicKey rule_set = 1;
 }
-    
+
 message MigrationTypeCollectionV1 {
 }
-    
+
 message MigrationTypeProgrammableV1 {
 }
-    
+
 message TokenStateUnlocked {
 }
-    
+
 message TokenStateLocked {
 }
-    
+
 message TokenStateListed {
 }
-    
+
 message TokenDelegateRoleSale {
 }
-    
+
 message TokenDelegateRoleTransfer {
 }
-    
+
 message TokenDelegateRoleUtility {
 }
-    
+
 message TokenDelegateRoleStaking {
 }
-    
+
 message TokenDelegateRoleStandard {
 }
-    
+
 message TokenDelegateRoleLockedTransfer {
 }
-    
+
 message TokenDelegateRoleMigration {
 }
-    
+
 message AuthorityTypeNone {
 }
-    
+
 message AuthorityTypeMetadata {
 }
-    
+
 message AuthorityTypeHolder {
 }
-    
+
 message AuthorityTypeMetadataDelegate {
 }
-    
+
 message AuthorityTypeTokenDelegate {
 }
-    
+
 message PayloadKeyAmount {
 }
-    
+
 message PayloadKeyAuthority {
 }
-    
+
 message PayloadKeyAuthoritySeeds {
 }
-    
+
 message PayloadKeyDelegate {
 }
-    
+
 message PayloadKeyDelegateSeeds {
 }
-    
+
 message PayloadKeyDestination {
 }
-    
+
 message PayloadKeyDestinationSeeds {
 }
-    
+
 message PayloadKeyHolder {
 }
-    
+
 message PayloadKeySource {
 }
-    
+
 message PayloadKeySourceSeeds {
 }
-    
+
 message PayloadTypePubkey {
   PublicKey item_0 = 1;
 }
-    
+
 message PayloadTypeSeeds {
   SeedsVec item_0 = 1;
 }
-    
+
 message PayloadTypeMerkleProof {
   ProofInfo item_0 = 1;
 }
-    
+
 message PayloadTypeNumber {
   uint64 item_0 = 1;
 }
-    
+
 message UseMethodBurn {
 }
-    
+
 message UseMethodMultiple {
 }
-    
+
 message UseMethodSingle {
 }
-    
+
 message CollectionAuthorityRecord {
   Key key = 1;
   uint32 bump = 2;
   optional PublicKey update_authority = 3;
 }
-    
+
 message MetadataDelegateRecord {
   Key key = 1;
   uint32 bump = 2;
@@ -632,7 +632,7 @@ message MetadataDelegateRecord {
   PublicKey delegate = 4;
   PublicKey update_authority = 5;
 }
-    
+
 message HolderDelegateRecord {
   Key key = 1;
   uint32 bump = 2;
@@ -640,36 +640,36 @@ message HolderDelegateRecord {
   PublicKey delegate = 4;
   PublicKey update_authority = 5;
 }
-    
+
 message Edition {
   Key key = 1;
   PublicKey parent = 2;
   uint64 edition = 3;
 }
-    
+
 message EditionMarker {
   Key key = 1;
   bytes ledger = 2;
 }
-    
+
 message EditionMarkerV2 {
   Key key = 1;
   bytes ledger = 2;
 }
-    
+
 message TokenOwnedEscrow {
   Key key = 1;
   PublicKey base_token = 2;
   EscrowAuthority authority = 3;
   uint32 bump = 4;
 }
-    
+
 message MasterEditionV2 {
   Key key = 1;
   uint64 supply = 2;
   optional uint64 max_supply = 3;
 }
-    
+
 message MasterEditionV1 {
   Key key = 1;
   uint64 supply = 2;
@@ -677,7 +677,7 @@ message MasterEditionV1 {
   PublicKey printing_mint = 4;
   PublicKey one_time_printing_authorization_mint = 5;
 }
-    
+
 message Metadata {
   Key key = 1;
   PublicKey update_authority = 2;
@@ -692,7 +692,7 @@ message Metadata {
   optional CollectionDetails collection_details = 11;
   optional ProgrammableConfig programmable_config = 12;
 }
-    
+
 message TokenRecord {
   Key key = 1;
   uint32 bump = 2;
@@ -702,7 +702,7 @@ message TokenRecord {
   optional TokenDelegateRole delegate_role = 6;
   optional PublicKey locked_transfer = 7;
 }
-    
+
 message ReservationListV2 {
   Key key = 1;
   PublicKey master_edition = 2;
@@ -711,20 +711,20 @@ message ReservationListV2 {
   uint64 total_reservation_spots = 5;
   uint64 current_reservation_spots = 6;
 }
-    
+
 message ReservationListV1 {
   Key key = 1;
   PublicKey master_edition = 2;
   optional uint64 supply_snapshot = 3;
   repeated ReservationV1 reservations = 4;
 }
-    
+
 message UseAuthorityRecord {
   Key key = 1;
   uint64 allowed_uses = 2;
   uint32 bump = 3;
 }
-    
+
 message TokenMetadataAccount {
   oneof account {
     CollectionAuthorityRecord collection_authority_record = 1;

--- a/tests/proc-macro/tests/snapshots/metaplex__check_protobuf_schema.snap
+++ b/tests/proc-macro/tests/snapshots/metaplex__check_protobuf_schema.snap
@@ -52,12 +52,16 @@ message AuthorizationData {
   Payload payload = 1;
 }
     
+message AssetDataCreatorsOption {
+  repeated Creator value = 1;
+}
+    
 message AssetData {
   string name = 1;
   string symbol = 2;
   string uri = 3;
   uint32 seller_fee_basis_points = 4;
-  optional Creator creators = 5;
+  optional AssetDataCreatorsOption creators = 5;
   bool primary_sale_happened = 6;
   bool is_mutable = 7;
   TokenStandard token_standard = 8;
@@ -78,12 +82,20 @@ message Creator {
   uint32 share = 3;
 }
     
+message DataCreatorsOption {
+  repeated Creator value = 1;
+}
+    
 message Data {
   string name = 1;
   string symbol = 2;
   string uri = 3;
   uint32 seller_fee_basis_points = 4;
-  optional Creator creators = 5;
+  optional DataCreatorsOption creators = 5;
+}
+    
+message DataV2CreatorsOption {
+  repeated Creator value = 1;
 }
     
 message DataV2 {
@@ -91,7 +103,7 @@ message DataV2 {
   string symbol = 2;
   string uri = 3;
   uint32 seller_fee_basis_points = 4;
-  optional Creator creators = 5;
+  optional DataV2CreatorsOption creators = 5;
   optional Collection collection = 6;
   optional Uses uses = 7;
 }

--- a/tests/proc-macro/tests/snapshots/spl_governance__check_protobuf_schema.snap
+++ b/tests/proc-macro/tests/snapshots/spl_governance__check_protobuf_schema.snap
@@ -1041,8 +1041,12 @@ message RelinquishTokenOwnerRecordLocksAccounts {
   repeated PublicKey remaining_accounts = 5;
 }
     
+message RelinquishTokenOwnerRecordLocksArgsLockIdsOption {
+  repeated uint32 value = 1;
+}
+    
 message RelinquishTokenOwnerRecordLocksArgs {
-  optional uint32 lock_ids = 1;
+  optional RelinquishTokenOwnerRecordLocksArgsLockIdsOption lock_ids = 1;
 }
     
 message RelinquishTokenOwnerRecordLocks {

--- a/tests/proc-macro/tests/snapshots/spl_governance__check_protobuf_schema.snap
+++ b/tests/proc-macro/tests/snapshots/spl_governance__check_protobuf_schema.snap
@@ -9,82 +9,82 @@ package spl_governance;
 message PublicKey {
   bytes value = 1;
 }
-    
+
 message GovernanceAccountTypeUninitialized {
 }
-    
+
 message GovernanceAccountTypeRealmV1 {
 }
-    
+
 message GovernanceAccountTypeTokenOwnerRecordV1 {
 }
-    
+
 message GovernanceAccountTypeGovernanceV1 {
 }
-    
+
 message GovernanceAccountTypeProgramGovernanceV1 {
 }
-    
+
 message GovernanceAccountTypeProposalV1 {
 }
-    
+
 message GovernanceAccountTypeSignatoryRecordV1 {
 }
-    
+
 message GovernanceAccountTypeVoteRecordV1 {
 }
-    
+
 message GovernanceAccountTypeProposalInstructionV1 {
 }
-    
+
 message GovernanceAccountTypeMintGovernanceV1 {
 }
-    
+
 message GovernanceAccountTypeTokenGovernanceV1 {
 }
-    
+
 message GovernanceAccountTypeRealmConfig {
 }
-    
+
 message GovernanceAccountTypeVoteRecordV2 {
 }
-    
+
 message GovernanceAccountTypeProposalTransactionV2 {
 }
-    
+
 message GovernanceAccountTypeProposalV2 {
 }
-    
+
 message GovernanceAccountTypeProgramMetadata {
 }
-    
+
 message GovernanceAccountTypeRealmV2 {
 }
-    
+
 message GovernanceAccountTypeTokenOwnerRecordV2 {
 }
-    
+
 message GovernanceAccountTypeGovernanceV2 {
 }
-    
+
 message GovernanceAccountTypeProgramGovernanceV2 {
 }
-    
+
 message GovernanceAccountTypeMintGovernanceV2 {
 }
-    
+
 message GovernanceAccountTypeTokenGovernanceV2 {
 }
-    
+
 message GovernanceAccountTypeSignatoryRecordV2 {
 }
-    
+
 message GovernanceAccountTypeProposalDeposit {
 }
-    
+
 message GovernanceAccountTypeRequiredSignatory {
 }
-    
+
 message GovernanceConfig {
   VoteThreshold community_vote_threshold = 1;
   uint64 min_community_weight_to_create_proposal = 2;
@@ -99,27 +99,27 @@ message GovernanceConfig {
   uint32 voting_cool_off_time = 11;
   uint32 deposit_exempt_proposal_count = 12;
 }
-    
+
 message VoteThresholdYesVotePercentage {
   uint32 item_0 = 1;
 }
-    
+
 message VoteThresholdQuorumPercentage {
   uint32 item_0 = 1;
 }
-    
+
 message VoteThresholdDisabled {
 }
-    
+
 message VoteTippingStrict {
 }
-    
+
 message VoteTippingEarly {
 }
-    
+
 message VoteTippingDisabled {
 }
-    
+
 message RealmConfigArgs {
   bool use_council_mint = 1;
   uint64 min_community_weight_to_create_governance = 2;
@@ -127,7 +127,7 @@ message RealmConfigArgs {
   GoverningTokenConfigArgs community_token_config_args = 4;
   GoverningTokenConfigArgs council_token_config_args = 5;
 }
-    
+
 message RealmConfig {
   uint32 legacy1 = 1;
   uint32 legacy2 = 2;
@@ -136,13 +136,13 @@ message RealmConfig {
   MintMaxVoterWeightSource community_mint_max_voter_weight_source = 5;
   optional PublicKey council_mint = 6;
 }
-    
+
 message GoverningTokenConfigArgs {
   bool use_voter_weight_addin = 1;
   bool use_max_voter_weight_addin = 2;
   GoverningTokenType token_type = 3;
 }
-    
+
 message GoverningTokenConfig {
   optional PublicKey voter_weight_addin = 1;
   optional PublicKey max_voter_weight_addin = 2;
@@ -150,91 +150,91 @@ message GoverningTokenConfig {
   bytes reserved = 4;
   repeated PublicKey lock_authorities = 5;
 }
-    
+
 message GoverningTokenTypeLiquid {
 }
-    
+
 message GoverningTokenTypeMembership {
 }
-    
+
 message GoverningTokenTypeDormant {
 }
-    
+
 message MintMaxVoterWeightSourceSupplyFraction {
   uint64 item_0 = 1;
 }
-    
+
 message MintMaxVoterWeightSourceAbsolute {
   uint64 item_0 = 1;
 }
-    
+
 message SetRealmAuthorityActionSetUnchecked {
 }
-    
+
 message SetRealmAuthorityActionSetChecked {
 }
-    
+
 message SetRealmAuthorityActionRemove {
 }
-    
+
 message SetRealmConfigItemArgsTokenOwnerRecordLockAuthority {
   SetConfigItemActionType action = 1;
   PublicKey governing_token_mint = 2;
   PublicKey authority = 3;
 }
-    
+
 message SetConfigItemActionTypeAdd {
 }
-    
+
 message SetConfigItemActionTypeRemove {
 }
-    
+
 message VoteTypeSingleChoice {
 }
-    
+
 message VoteTypeMultiChoice {
   MultiChoiceType choice_type = 1;
   uint32 min_voter_options = 2;
   uint32 max_voter_options = 3;
   uint32 max_winning_options = 4;
 }
-    
+
 message MultiChoiceTypeFullWeight {
 }
-    
+
 message MultiChoiceTypeWeighted {
 }
-    
+
 message ProposalStateDraft {
 }
-    
+
 message ProposalStateSigningOff {
 }
-    
+
 message ProposalStateVoting {
 }
-    
+
 message ProposalStateSucceeded {
 }
-    
+
 message ProposalStateExecuting {
 }
-    
+
 message ProposalStateCompleted {
 }
-    
+
 message ProposalStateCancelled {
 }
-    
+
 message ProposalStateDefeated {
 }
-    
+
 message ProposalStateExecutingWithErrors {
 }
-    
+
 message ProposalStateVetoed {
 }
-    
+
 message ProposalOption {
   string label = 1;
   uint64 vote_weight = 2;
@@ -243,88 +243,88 @@ message ProposalOption {
   uint32 transactions_count = 5;
   uint32 transactions_next_index = 6;
 }
-    
+
 message OptionVoteResultNone {
 }
-    
+
 message OptionVoteResultSucceeded {
 }
-    
+
 message OptionVoteResultDefeated {
 }
-    
+
 message InstructionExecutionFlagsNone {
 }
-    
+
 message InstructionExecutionFlagsOrdered {
 }
-    
+
 message InstructionExecutionFlagsUseTransaction {
 }
-    
+
 message TransactionExecutionStatusNone {
 }
-    
+
 message TransactionExecutionStatusSuccess {
 }
-    
+
 message TransactionExecutionStatusError {
 }
-    
+
 message InstructionData {
   PublicKey program_id = 1;
   repeated AccountMetaData accounts = 2;
   bytes data = 3;
 }
-    
+
 message AccountMetaData {
   PublicKey pubkey = 1;
   bool is_signer = 2;
   bool is_writable = 3;
 }
-    
+
 message VoteChoice {
   uint32 rank = 1;
   uint32 weight_percentage = 2;
 }
-    
+
 message VoteApprove {
   repeated VoteChoice item_0 = 1;
 }
-    
+
 message VoteDeny {
 }
-    
+
 message VoteAbstain {
 }
-    
+
 message VoteVeto {
 }
-    
+
 message VoteKindElectorate {
 }
-    
+
 message VoteKindVeto {
 }
-    
+
 message TokenOwnerRecordLock {
   uint32 lock_id = 1;
   PublicKey authority = 2;
   optional int64 expiry = 3;
 }
-    
+
 message Reserved110 {
   bytes reserved64 = 1;
   bytes reserved32 = 2;
   bytes reserved14 = 3;
 }
-    
+
 message Reserved119 {
   bytes reserved64 = 1;
   bytes reserved32 = 2;
   bytes reserved23 = 3;
 }
-    
+
 message RealmV2 {
   GovernanceAccountType account_type = 1;
   PublicKey community_mint = 2;
@@ -335,7 +335,7 @@ message RealmV2 {
   string name = 7;
   bytes reserved_v2 = 8;
 }
-    
+
 message RealmConfigAccount {
   GovernanceAccountType account_type = 1;
   PublicKey realm = 2;
@@ -343,7 +343,7 @@ message RealmConfigAccount {
   GoverningTokenConfig council_token_config = 4;
   Reserved110 reserved = 5;
 }
-    
+
 message GovernanceV2 {
   GovernanceAccountType account_type = 1;
   PublicKey realm = 2;
@@ -354,7 +354,7 @@ message GovernanceV2 {
   uint32 required_signatories_count = 7;
   uint64 active_proposal_count = 8;
 }
-    
+
 message ProposalV2 {
   GovernanceAccountType account_type = 1;
   PublicKey governance = 2;
@@ -385,7 +385,7 @@ message ProposalV2 {
   string description_link = 27;
   uint64 veto_vote_weight = 28;
 }
-    
+
 message ProposalTransactionV2 {
   GovernanceAccountType account_type = 1;
   PublicKey proposal = 2;
@@ -397,7 +397,7 @@ message ProposalTransactionV2 {
   TransactionExecutionStatus execution_status = 8;
   bytes reserved_v2 = 9;
 }
-    
+
 message SignatoryRecordV2 {
   GovernanceAccountType account_type = 1;
   PublicKey proposal = 2;
@@ -405,7 +405,7 @@ message SignatoryRecordV2 {
   bool signed_off = 4;
   bytes reserved_v2 = 5;
 }
-    
+
 message VoteRecordV2 {
   GovernanceAccountType account_type = 1;
   PublicKey proposal = 2;
@@ -415,7 +415,7 @@ message VoteRecordV2 {
   Vote vote = 6;
   bytes reserved_v2 = 7;
 }
-    
+
 message TokenOwnerRecordV2 {
   GovernanceAccountType account_type = 1;
   PublicKey realm = 2;
@@ -430,31 +430,31 @@ message TokenOwnerRecordV2 {
   bytes reserved_v2 = 11;
   repeated TokenOwnerRecordLock locks = 12;
 }
-    
+
 message ProgramMetadata {
   GovernanceAccountType account_type = 1;
   uint64 updated_at = 2;
   string version = 3;
   bytes reserved = 4;
 }
-    
+
 message ProposalDeposit {
   GovernanceAccountType account_type = 1;
   PublicKey proposal = 2;
   PublicKey deposit_payer = 3;
   bytes reserved = 4;
 }
-    
+
 message RequiredSignatory {
   GovernanceAccountType account_type = 1;
   uint32 account_version = 2;
   PublicKey governance = 3;
   PublicKey signatory = 4;
 }
-    
+
 message NativeTreasury {
 }
-    
+
 message CreateRealmAccounts {
   PublicKey realm = 1;
   PublicKey realm_authority = 2;
@@ -473,17 +473,17 @@ message CreateRealmAccounts {
   optional PublicKey council_max_voter_weight_addin_program = 15;
   repeated PublicKey remaining_accounts = 16;
 }
-    
+
 message CreateRealmArgs {
   string name = 1;
   RealmConfigArgs config_args = 2;
 }
-    
+
 message CreateRealm {
   CreateRealmAccounts accounts = 1;
   CreateRealmArgs args = 2;
 }
-    
+
 message DepositGoverningTokensAccounts {
   PublicKey realm = 1;
   PublicKey governing_token_holding = 2;
@@ -497,16 +497,16 @@ message DepositGoverningTokensAccounts {
   PublicKey realm_config = 10;
   repeated PublicKey remaining_accounts = 11;
 }
-    
+
 message DepositGoverningTokensArgs {
   uint64 amount = 1;
 }
-    
+
 message DepositGoverningTokens {
   DepositGoverningTokensAccounts accounts = 1;
   DepositGoverningTokensArgs args = 2;
 }
-    
+
 message WithdrawGoverningTokensAccounts {
   PublicKey realm = 1;
   PublicKey governing_token_holding = 2;
@@ -517,30 +517,30 @@ message WithdrawGoverningTokensAccounts {
   PublicKey realm_config = 7;
   repeated PublicKey remaining_accounts = 8;
 }
-    
+
 message WithdrawGoverningTokensArgs {
 }
-    
+
 message WithdrawGoverningTokens {
   WithdrawGoverningTokensAccounts accounts = 1;
   WithdrawGoverningTokensArgs args = 2;
 }
-    
+
 message SetGovernanceDelegateAccounts {
   PublicKey governance_authority = 1;
   PublicKey token_owner_record = 2;
   repeated PublicKey remaining_accounts = 3;
 }
-    
+
 message SetGovernanceDelegateArgs {
   optional PublicKey new_governance_delegate = 1;
 }
-    
+
 message SetGovernanceDelegate {
   SetGovernanceDelegateAccounts accounts = 1;
   SetGovernanceDelegateArgs args = 2;
 }
-    
+
 message CreateGovernanceAccounts {
   PublicKey realm = 1;
   PublicKey governance = 2;
@@ -553,28 +553,28 @@ message CreateGovernanceAccounts {
   optional PublicKey voter_weight_record = 9;
   repeated PublicKey remaining_accounts = 10;
 }
-    
+
 message CreateGovernanceArgs {
   GovernanceConfig config = 1;
 }
-    
+
 message CreateGovernance {
   CreateGovernanceAccounts accounts = 1;
   CreateGovernanceArgs args = 2;
 }
-    
+
 message Legacy4Accounts {
   repeated PublicKey remaining_accounts = 1;
 }
-    
+
 message Legacy4Args {
 }
-    
+
 message Legacy4 {
   Legacy4Accounts accounts = 1;
   Legacy4Args args = 2;
 }
-    
+
 message CreateProposalAccounts {
   PublicKey realm = 1;
   PublicKey proposal = 2;
@@ -589,7 +589,7 @@ message CreateProposalAccounts {
   optional PublicKey proposal_deposit = 11;
   repeated PublicKey remaining_accounts = 12;
 }
-    
+
 message CreateProposalArgs {
   string name = 1;
   string description_link = 2;
@@ -598,12 +598,12 @@ message CreateProposalArgs {
   bool use_deny_option = 5;
   PublicKey proposal_seed = 6;
 }
-    
+
 message CreateProposal {
   CreateProposalAccounts accounts = 1;
   CreateProposalArgs args = 2;
 }
-    
+
 message AddSignatoryAccounts {
   PublicKey governance = 1;
   PublicKey proposal = 2;
@@ -614,28 +614,28 @@ message AddSignatoryAccounts {
   optional PublicKey governance_authority = 7;
   repeated PublicKey remaining_accounts = 8;
 }
-    
+
 message AddSignatoryArgs {
   PublicKey signatory = 1;
 }
-    
+
 message AddSignatory {
   AddSignatoryAccounts accounts = 1;
   AddSignatoryArgs args = 2;
 }
-    
+
 message Legacy1Accounts {
   repeated PublicKey remaining_accounts = 1;
 }
-    
+
 message Legacy1Args {
 }
-    
+
 message Legacy1 {
   Legacy1Accounts accounts = 1;
   Legacy1Args args = 2;
 }
-    
+
 message InsertTransactionAccounts {
   PublicKey governance = 1;
   PublicKey proposal = 2;
@@ -647,19 +647,19 @@ message InsertTransactionAccounts {
   PublicKey rent = 8;
   repeated PublicKey remaining_accounts = 9;
 }
-    
+
 message InsertTransactionArgs {
   uint32 option_index = 1;
   uint32 index = 2;
   uint32 legacy = 3;
   repeated InstructionData instructions = 4;
 }
-    
+
 message InsertTransaction {
   InsertTransactionAccounts accounts = 1;
   InsertTransactionArgs args = 2;
 }
-    
+
 message RemoveTransactionAccounts {
   PublicKey proposal = 1;
   PublicKey token_owner_record = 2;
@@ -668,15 +668,15 @@ message RemoveTransactionAccounts {
   PublicKey beneficiary = 5;
   repeated PublicKey remaining_accounts = 6;
 }
-    
+
 message RemoveTransactionArgs {
 }
-    
+
 message RemoveTransaction {
   RemoveTransactionAccounts accounts = 1;
   RemoveTransactionArgs args = 2;
 }
-    
+
 message CancelProposalAccounts {
   PublicKey realm = 1;
   PublicKey governance = 2;
@@ -685,15 +685,15 @@ message CancelProposalAccounts {
   PublicKey governance_authority = 5;
   repeated PublicKey remaining_accounts = 6;
 }
-    
+
 message CancelProposalArgs {
 }
-    
+
 message CancelProposal {
   CancelProposalAccounts accounts = 1;
   CancelProposalArgs args = 2;
 }
-    
+
 message SignOffProposalAccounts {
   PublicKey realm = 1;
   PublicKey governance = 2;
@@ -702,15 +702,15 @@ message SignOffProposalAccounts {
   PublicKey proposal_owner_record_or_signatory_record = 5;
   repeated PublicKey remaining_accounts = 6;
 }
-    
+
 message SignOffProposalArgs {
 }
-    
+
 message SignOffProposal {
   SignOffProposalAccounts accounts = 1;
   SignOffProposalArgs args = 2;
 }
-    
+
 message CastVoteAccounts {
   PublicKey realm = 1;
   PublicKey governance = 2;
@@ -727,16 +727,16 @@ message CastVoteAccounts {
   optional PublicKey max_voter_weight_record = 13;
   repeated PublicKey remaining_accounts = 14;
 }
-    
+
 message CastVoteArgs {
   Vote vote = 1;
 }
-    
+
 message CastVote {
   CastVoteAccounts accounts = 1;
   CastVoteArgs args = 2;
 }
-    
+
 message FinalizeVoteAccounts {
   PublicKey realm = 1;
   PublicKey governance = 2;
@@ -747,15 +747,15 @@ message FinalizeVoteAccounts {
   optional PublicKey max_voter_weight_record = 7;
   repeated PublicKey remaining_accounts = 8;
 }
-    
+
 message FinalizeVoteArgs {
 }
-    
+
 message FinalizeVote {
   FinalizeVoteAccounts accounts = 1;
   FinalizeVoteArgs args = 2;
 }
-    
+
 message RelinquishVoteAccounts {
   PublicKey realm = 1;
   PublicKey governance = 2;
@@ -767,15 +767,15 @@ message RelinquishVoteAccounts {
   optional PublicKey beneficiary = 8;
   repeated PublicKey remaining_accounts = 9;
 }
-    
+
 message RelinquishVoteArgs {
 }
-    
+
 message RelinquishVote {
   RelinquishVoteAccounts accounts = 1;
   RelinquishVoteArgs args = 2;
 }
-    
+
 message ExecuteTransactionAccounts {
   PublicKey governance = 1;
   PublicKey proposal = 2;
@@ -783,81 +783,81 @@ message ExecuteTransactionAccounts {
   PublicKey instruction_program = 4;
   optional PublicKey remaining_accounts = 5;
 }
-    
+
 message ExecuteTransactionArgs {
 }
-    
+
 message ExecuteTransaction {
   ExecuteTransactionAccounts accounts = 1;
   ExecuteTransactionArgs args = 2;
 }
-    
+
 message Legacy2Accounts {
   repeated PublicKey remaining_accounts = 1;
 }
-    
+
 message Legacy2Args {
 }
-    
+
 message Legacy2 {
   Legacy2Accounts accounts = 1;
   Legacy2Args args = 2;
 }
-    
+
 message Legacy3Accounts {
   repeated PublicKey remaining_accounts = 1;
 }
-    
+
 message Legacy3Args {
 }
-    
+
 message Legacy3 {
   Legacy3Accounts accounts = 1;
   Legacy3Args args = 2;
 }
-    
+
 message SetGovernanceConfigAccounts {
   PublicKey governance = 1;
   repeated PublicKey remaining_accounts = 2;
 }
-    
+
 message SetGovernanceConfigArgs {
   GovernanceConfig config = 1;
 }
-    
+
 message SetGovernanceConfig {
   SetGovernanceConfigAccounts accounts = 1;
   SetGovernanceConfigArgs args = 2;
 }
-    
+
 message Legacy5Accounts {
   repeated PublicKey remaining_accounts = 1;
 }
-    
+
 message Legacy5Args {
 }
-    
+
 message Legacy5 {
   Legacy5Accounts accounts = 1;
   Legacy5Args args = 2;
 }
-    
+
 message SetRealmAuthorityAccounts {
   PublicKey realm = 1;
   PublicKey realm_authority = 2;
   optional PublicKey new_realm_authority = 3;
   repeated PublicKey remaining_accounts = 4;
 }
-    
+
 message SetRealmAuthorityArgs {
   SetRealmAuthorityAction action = 1;
 }
-    
+
 message SetRealmAuthority {
   SetRealmAuthorityAccounts accounts = 1;
   SetRealmAuthorityArgs args = 2;
 }
-    
+
 message SetRealmConfigAccounts {
   PublicKey realm = 1;
   PublicKey realm_authority = 2;
@@ -872,16 +872,16 @@ message SetRealmConfigAccounts {
   optional PublicKey payer = 11;
   repeated PublicKey remaining_accounts = 12;
 }
-    
+
 message SetRealmConfigArgs {
   RealmConfigArgs config_args = 1;
 }
-    
+
 message SetRealmConfig {
   SetRealmConfigAccounts accounts = 1;
   SetRealmConfigArgs args = 2;
 }
-    
+
 message CreateTokenOwnerRecordAccounts {
   PublicKey realm = 1;
   PublicKey governing_token_owner = 2;
@@ -891,30 +891,30 @@ message CreateTokenOwnerRecordAccounts {
   PublicKey system_program = 6;
   repeated PublicKey remaining_accounts = 7;
 }
-    
+
 message CreateTokenOwnerRecordArgs {
 }
-    
+
 message CreateTokenOwnerRecord {
   CreateTokenOwnerRecordAccounts accounts = 1;
   CreateTokenOwnerRecordArgs args = 2;
 }
-    
+
 message UpdateProgramMetadataAccounts {
   PublicKey program_metadata = 1;
   PublicKey payer = 2;
   PublicKey system_program = 3;
   repeated PublicKey remaining_accounts = 4;
 }
-    
+
 message UpdateProgramMetadataArgs {
 }
-    
+
 message UpdateProgramMetadata {
   UpdateProgramMetadataAccounts accounts = 1;
   UpdateProgramMetadataArgs args = 2;
 }
-    
+
 message CreateNativeTreasuryAccounts {
   PublicKey governance = 1;
   PublicKey native_treasury = 2;
@@ -922,15 +922,15 @@ message CreateNativeTreasuryAccounts {
   PublicKey system_program = 4;
   repeated PublicKey remaining_accounts = 5;
 }
-    
+
 message CreateNativeTreasuryArgs {
 }
-    
+
 message CreateNativeTreasury {
   CreateNativeTreasuryAccounts accounts = 1;
   CreateNativeTreasuryArgs args = 2;
 }
-    
+
 message RevokeGoverningTokensAccounts {
   PublicKey realm = 1;
   PublicKey governing_token_holding = 2;
@@ -941,46 +941,46 @@ message RevokeGoverningTokensAccounts {
   PublicKey spl_token_program = 7;
   repeated PublicKey remaining_accounts = 8;
 }
-    
+
 message RevokeGoverningTokensArgs {
   uint64 amount = 1;
 }
-    
+
 message RevokeGoverningTokens {
   RevokeGoverningTokensAccounts accounts = 1;
   RevokeGoverningTokensArgs args = 2;
 }
-    
+
 message RefundProposalDepositAccounts {
   PublicKey proposal = 1;
   PublicKey proposal_deposit = 2;
   PublicKey proposal_deposit_payer = 3;
   repeated PublicKey remaining_accounts = 4;
 }
-    
+
 message RefundProposalDepositArgs {
 }
-    
+
 message RefundProposalDeposit {
   RefundProposalDepositAccounts accounts = 1;
   RefundProposalDepositArgs args = 2;
 }
-    
+
 message CompleteProposalAccounts {
   PublicKey proposal = 1;
   PublicKey token_owner_record = 2;
   PublicKey complete_proposal_authority = 3;
   repeated PublicKey remaining_accounts = 4;
 }
-    
+
 message CompleteProposalArgs {
 }
-    
+
 message CompleteProposal {
   CompleteProposalAccounts accounts = 1;
   CompleteProposalArgs args = 2;
 }
-    
+
 message AddRequiredSignatoryAccounts {
   PublicKey governance = 1;
   PublicKey required_signatory = 2;
@@ -988,31 +988,31 @@ message AddRequiredSignatoryAccounts {
   PublicKey system_program = 4;
   repeated PublicKey remaining_accounts = 5;
 }
-    
+
 message AddRequiredSignatoryArgs {
   PublicKey signatory = 1;
 }
-    
+
 message AddRequiredSignatory {
   AddRequiredSignatoryAccounts accounts = 1;
   AddRequiredSignatoryArgs args = 2;
 }
-    
+
 message RemoveRequiredSignatoryAccounts {
   PublicKey governance = 1;
   PublicKey required_signatory = 2;
   PublicKey beneficiary = 3;
   repeated PublicKey remaining_accounts = 4;
 }
-    
+
 message RemoveRequiredSignatoryArgs {
 }
-    
+
 message RemoveRequiredSignatory {
   RemoveRequiredSignatoryAccounts accounts = 1;
   RemoveRequiredSignatoryArgs args = 2;
 }
-    
+
 message SetTokenOwnerRecordLockAccounts {
   PublicKey realm = 1;
   PublicKey realm_config = 2;
@@ -1022,17 +1022,17 @@ message SetTokenOwnerRecordLockAccounts {
   PublicKey system_program = 6;
   repeated PublicKey remaining_accounts = 7;
 }
-    
+
 message SetTokenOwnerRecordLockArgs {
   uint32 lock_id = 1;
   optional int64 expiry = 2;
 }
-    
+
 message SetTokenOwnerRecordLock {
   SetTokenOwnerRecordLockAccounts accounts = 1;
   SetTokenOwnerRecordLockArgs args = 2;
 }
-    
+
 message RelinquishTokenOwnerRecordLocksAccounts {
   PublicKey realm = 1;
   PublicKey realm_config = 2;
@@ -1040,20 +1040,20 @@ message RelinquishTokenOwnerRecordLocksAccounts {
   optional PublicKey token_owner_record_lock_authority = 4;
   repeated PublicKey remaining_accounts = 5;
 }
-    
+
 message RelinquishTokenOwnerRecordLocksArgsLockIdsOption {
   repeated uint32 value = 1;
 }
-    
+
 message RelinquishTokenOwnerRecordLocksArgs {
   optional RelinquishTokenOwnerRecordLocksArgsLockIdsOption lock_ids = 1;
 }
-    
+
 message RelinquishTokenOwnerRecordLocks {
   RelinquishTokenOwnerRecordLocksAccounts accounts = 1;
   RelinquishTokenOwnerRecordLocksArgs args = 2;
 }
-    
+
 message SetRealmConfigItemAccounts {
   PublicKey realm = 1;
   PublicKey realm_config = 2;
@@ -1062,12 +1062,12 @@ message SetRealmConfigItemAccounts {
   PublicKey system_program = 5;
   repeated PublicKey remaining_accounts = 6;
 }
-    
+
 message SetRealmConfigItem {
   SetRealmConfigItemAccounts accounts = 1;
   SetRealmConfigItemArgs args = 2;
 }
-    
+
 message SplGovernanceAccount {
   oneof account {
     RealmV2 realm_v2 = 1;

--- a/tests/proc-macro/tests/spl_governance.rs
+++ b/tests/proc-macro/tests/spl_governance.rs
@@ -10,7 +10,9 @@ include_vixen_parser!("../idls/spl_governance.json");
 fn check_protobuf_schema() {
     check_protobuf_format(spl_governance::PROTOBUF_SCHEMA);
 
-    insta::assert_snapshot!(spl_governance::PROTOBUF_SCHEMA);
+    insta::assert_snapshot!(vixen_test_utils::normalize_protobuf_schema_for_snapshot(
+        spl_governance::PROTOBUF_SCHEMA
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
- Adds support for inline structs, tuples, arrays, and options nested inside one another.
- Materializes anonymous types into named helper messages.
- Preserves wrappers such as Option<Vec<T>> instead of flattening them incorrectly
- Fixes generated protobuf schemas like Option<Vec<u8>> becoming an optional wrapper message rather than optional uint32.
- Refactors the intermediate representation and updates generated Rust/protobuf output and snapshots.
- Also removes the unsafe Schema Registry fallback to the latest schema after registration errors.