### PR TITLE
fix(config): don't crash on startup when [buffer] omits sources-chann…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14011,6 +14011,7 @@ dependencies = [
  "opentelemetry 0.24.0",
  "prometheus",
  "serde",
+ "serde_json",
  "smallvec",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -27,6 +27,7 @@ yellowstone-vixen-core = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "test-util"] }
 yellowstone-grpc-proto = { workspace = true }
 

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -46,6 +46,8 @@ where S: Args + Deserialize<'de>
     }
 }
 
+const fn default_sources_channel_size() -> usize { 100 }
+
 /// Job scheduler configuration.
 #[derive(Debug, Clone, Copy, clap::Args, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -55,8 +57,11 @@ pub struct BufferConfig {
     #[arg(long, env)]
     pub jobs: Option<usize>,
     /// The maximum number of concurrent sources to run.
-    /// Defaults to 100.
-    #[arg(long, env)]
+    ///
+    /// Defaults to 100: a `[buffer]` section omitting this key (including ones
+    /// that predate the field) still deserializes.
+    #[arg(long, env, default_value_t = 100)]
+    #[serde(default = "default_sources_channel_size")]
     pub sources_channel_size: usize,
 }
 
@@ -178,4 +183,42 @@ where T::Owned: Into<U> {
     let ret = f(&mut u);
     *t = u.into();
     ret
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BufferConfig;
+
+    #[test]
+    fn partial_buffer_fills_in_channel_size_default() {
+        let cfg: BufferConfig =
+            serde_json::from_str(r#"{ "jobs": 8 }"#).expect("partial config must deserialize");
+
+        assert_eq!(cfg.sources_channel_size, 100);
+    }
+
+    #[test]
+    fn full_buffer_is_respected() {
+        let cfg: BufferConfig =
+            serde_json::from_str(r#"{ "jobs": 4, "sources-channel-size": 250 }"#).unwrap();
+
+        assert_eq!(cfg.sources_channel_size, 250);
+    }
+
+    /// The clap half of the same gap: without a `default_value_t`, a non-`Option`
+    /// field makes `--sources-channel-size` a required argument.
+    #[test]
+    fn clap_defaults_channel_size_when_flag_is_absent() {
+        use clap::Parser as _;
+
+        #[derive(clap::Parser)]
+        struct Opts {
+            #[command(flatten)]
+            buffer: BufferConfig,
+        }
+
+        let Opts { buffer } = Opts::try_parse_from(["test"]).expect("flag must be optional");
+
+        assert_eq!(buffer.sources_channel_size, 100);
+    }
 }


### PR DESCRIPTION
A `[buffer]` section that sets `jobs` but leaves out `sources-channel-size` failed to deserialize and killed the process before it could connect:

```toml
[buffer]
jobs = 8
# sources-channel-size omitted -> crash on startup
```

There's a `Default` impl with `100`, but serde never uses it for a missing field. This adds a serde default (and a clap default) so it falls back to `100`, same as `auto_reconnect` already does in the `grpc-source` crate.

```rust
const fn default_sources_channel_size() -> usize { 100 }

/// The maximum number of concurrent sources to run.
///
/// Defaults to 100: a `[buffer]` section omitting this key (including ones
/// that predate the field) still deserializes.
#[arg(long, env, default_value_t = 100)]
#[serde(default = "default_sources_channel_size")]
pub sources_channel_size: usize,
```

Covered by tests: a partial `[buffer]` fills in the default, a full one is respected, and the clap flag is optional.