### PR TITLE
fix(kafka-sink): dispatch account updates only to their owner parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --lib --tests
 
+      - name: Run experimental account parser tests
+        run: cargo test -p yellowstone-vixen-kafka-sink --features experimental-account-parser --lib --tests
+
   test-events:
     runs-on: ubuntu-24.04
     steps:
@@ -151,3 +154,6 @@ jobs:
 
       - name: Run clippy
         run: cargo clippy --all-targets --tests --no-deps -- -Dwarnings
+
+      - name: Run experimental account parser clippy
+        run: cargo clippy -p yellowstone-vixen-kafka-sink --features experimental-account-parser --all-targets --tests --no-deps -- -Dwarnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,4 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang cmake libcurl4-openssl-dev libsasl2-dev
 
       - name: Run clippy
-        run: cargo clippy --all-targets --tests --no-deps -- -Dwarnings
-
-      - name: Run experimental account parser clippy
-        run: cargo clippy -p yellowstone-vixen-kafka-sink --features experimental-account-parser --all-targets --tests --no-deps -- -Dwarnings
+        run: cargo clippy --all-targets --tests --no-deps --features yellowstone-vixen-kafka-sink/experimental-account-parser -- -Dwarnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ warp = "0.3"
 
 yellowstone-block-machine = { version = "0.4.0" }
 yellowstone-fumarole-client = "0.4.0+solana.3"
-yellowstone-grpc-client = { version = "13.1" }
+yellowstone-grpc-client = { version = ">=13.1, <13.3" }
 yellowstone-grpc-proto = { version = "12.4", default-features = false }
 rdkafka = { version = "0.36", features = ["cmake-build", "ssl", "zstd"] }
 reqwest = { version = "0.12", features = ["json", "blocking", "stream"] }

--- a/crates/kafka-sink/src/sink.rs
+++ b/crates/kafka-sink/src/sink.rs
@@ -603,6 +603,10 @@ impl KafkaSink {
         let mut had_error = false;
 
         for parser in &self.account_parsers {
+            if parser.program_id().0.as_slice() != inner.owner.as_slice() {
+                continue;
+            }
+
             match parser.try_parse(acct).await {
                 ParseOutcome::Parsed(parsed) => {
                     return (
@@ -852,6 +856,7 @@ mod tests {
     struct TestAccountParser {
         program_id: Pubkey,
         outcome: TestAccountOutcome,
+        calls: Arc<AtomicUsize>,
     }
 
     #[cfg(feature = "experimental-account-parser")]
@@ -871,6 +876,8 @@ mod tests {
         fn prefilter(&self) -> Prefilter { Prefilter::default() }
 
         async fn parse(&self, value: &Self::Input) -> ParseResult<Self::Output> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+
             let owner = value
                 .account
                 .as_ref()
@@ -924,7 +931,7 @@ mod tests {
                 txn_signature: None,
                 write_version: 11,
                 pubkey: vec![2_u8; 32],
-                data: vec![9_u8, 8, 7].into(),
+                data: vec![9_u8, 8, 7],
                 executable: false,
                 lamports: 1,
                 owner: owner.0.to_vec(),
@@ -1146,6 +1153,7 @@ mod tests {
         let parser = TestAccountParser {
             program_id: [1; 32].into(),
             outcome: TestAccountOutcome::Filtered,
+            calls: Arc::new(AtomicUsize::new(0)),
         };
 
         let sink = KafkaSinkBuilder::new()
@@ -1165,6 +1173,7 @@ mod tests {
         let parser = TestAccountParser {
             program_id: [1; 32].into(),
             outcome: TestAccountOutcome::Error,
+            calls: Arc::new(AtomicUsize::new(0)),
         };
 
         let sink = KafkaSinkBuilder::new()
@@ -1203,6 +1212,7 @@ mod tests {
         let parser = TestAccountParser {
             program_id: [1; 32].into(),
             outcome: TestAccountOutcome::Parsed,
+            calls: Arc::new(AtomicUsize::new(0)),
         };
 
         let sink = KafkaSinkBuilder::new()
@@ -1224,5 +1234,30 @@ mod tests {
             .headers
             .iter()
             .any(|header| { header.key == "write_version" && header.value == "11" }));
+    }
+
+    #[cfg(feature = "experimental-account-parser")]
+    #[test]
+    fn unrelated_account_does_not_invoke_parser_or_route_to_fallback_topic() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let parser = TestAccountParser {
+            program_id: [1; 32].into(),
+            outcome: TestAccountOutcome::Error,
+            calls: Arc::clone(&calls),
+        };
+
+        let sink = KafkaSinkBuilder::new()
+            .account_parser_with_fallback(parser, "test", "test.accounts", "failed.test.accounts")
+            .build();
+
+        let acct = account_with_owner([9; 32].into());
+        let (record, had_error) = futures::executor::block_on(sink.parse_account(100, &acct));
+
+        assert!(record.is_none(), "unrelated account must not emit a record");
+        assert!(
+            !had_error,
+            "unrelated account must not count as a parse error"
+        );
+        assert_eq!(calls.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/kafka-sink/src/sink.rs
+++ b/crates/kafka-sink/src/sink.rs
@@ -583,7 +583,8 @@ impl KafkaSink {
 
     /// Parse an account update and prepare a Kafka record.
     ///
-    /// Tries each registered account parser. On match, builds a decoded account record.
+    /// Tries each registered account parser associated with the account owner. On match, builds a
+    /// decoded account record.
     /// On `Error`, checks if that parser has a fallback_topic.
     /// Returns the record (if any) and a `had_error` flag.
     pub async fn parse_account(

--- a/tests/proc-macro-events/Cargo.lock
+++ b/tests/proc-macro-events/Cargo.lock
@@ -362,7 +362,7 @@ dependencies = [
  "pin-project-lite",
  "serde_core",
  "sync_wrapper",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -430,7 +430,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -441,12 +441,6 @@ dependencies = [
  "shlex",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -1021,19 +1015,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,15 +1038,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1222,7 +1194,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "lock_api",
  "once_cell",
- "parking_lot_core 0.9.12",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1339,26 +1311,6 @@ name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "dispose"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425462ba555fb628fbb7d9750d52f01fc9132d855996f34f02b7164b1b62860f"
-dependencies = [
- "dispose-derive",
-]
-
-[[package]]
-name = "dispose-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c32e3e8ab1b6ee2e06418f40f94f315d82b35157eb1d2322a6e20a4b15106b84"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1846,7 +1798,7 @@ dependencies = [
  "futures-timer",
  "no-std-compat",
  "nonzero_ext",
- "parking_lot 0.12.5",
+ "parking_lot",
  "portable-atomic",
  "quanta",
  "rand 0.8.5",
@@ -2269,15 +2221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,7 +2588,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2851,7 +2794,7 @@ version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2896,37 +2839,12 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -2937,7 +2855,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -3277,7 +3195,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "memchr",
  "unicase",
 ]
@@ -3497,7 +3415,7 @@ version = "11.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3555,20 +3473,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
 ]
 
 [[package]]
@@ -3637,7 +3546,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -3723,7 +3632,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3861,7 +3770,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4309,7 +4218,7 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52e52720efe60465b052b9e7445a01c17550666beec855cce66f44766697bc2"
 dependencies = [
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]
@@ -4318,7 +4227,7 @@ version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "085db4906d89324cef2a30840d59eaecf3d4231c560ec7c9f6614a93c652f501"
 dependencies = [
- "parking_lot 0.12.5",
+ "parking_lot",
 ]
 
 [[package]]
@@ -4964,7 +4873,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0e85a6fad5c2d0c4f5b91d34b8ca47118fc593af706e523cdbedf846a954f57"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "solana-account-info 2.3.0",
  "solana-instruction 2.3.3",
  "solana-program-error 2.2.2",
@@ -4981,7 +4890,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ddf67876c541aa1e21ee1acae35c95c6fbc61119814bfef70579317a5e26955"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "solana-account-info 3.1.1",
  "solana-instruction 3.3.0",
  "solana-instruction-error",
@@ -5303,7 +5212,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6edf2f25743c95229ac0fdc32f8f5893ef738dbf332c669e9861d33ddb0f469d"
 dependencies = [
  "bincode",
- "bitflags 2.11.0",
+ "bitflags",
  "cfg_eval",
  "serde",
  "serde_derive",
@@ -7650,7 +7559,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -7802,7 +7711,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -7989,7 +7898,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8049,38 +7958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "topograph"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4ea92bd6b8d73d7987848398691db79e81e6f77f1f56e959ebcee077adebf3"
-dependencies = [
- "crossbeam",
- "dispose",
- "futures-util",
- "log",
- "num_cpus",
- "parking_lot 0.11.2",
- "pin-project",
- "thiserror 1.0.69",
- "tokio",
-]
-
-[[package]]
-name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8106,7 +7983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
- "bitflags 2.11.0",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8117,7 +7994,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -8506,7 +8383,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags",
  "hashbrown 0.15.2",
  "indexmap",
  "semver",
@@ -8957,7 +8834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -9037,31 +8914,38 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-grpc-client"
-version = "12.2.0"
+version = "13.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b250b0ed11fb0fb11b80e89599e6f5a77640bce3dafe26ffb8022cdfc6c49e"
+checksum = "522f732c75365ae8e7c1d4607f33fa7acb163389f00debfa773ed2e7566cc94b"
 dependencies = [
+ "arc-swap",
  "bytes",
  "futures",
+ "hyper",
  "hyper-util",
+ "log",
+ "pin-project",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
  "tonic-health",
- "tower 0.4.13",
+ "tower",
  "yellowstone-grpc-proto",
 ]
 
 [[package]]
 name = "yellowstone-grpc-proto"
-version = "12.1.0"
+version = "12.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab52445da59c3e710dd2128e3e49598cfa45c8ba7f30feb608cafbd404e5e8cf"
+checksum = "c91071690a2b0a078a4712ecca7be37aa929b474a74f4f269c61582f8e2a6139"
 dependencies = [
  "anyhow",
  "prost",
  "prost-types",
  "protoc-bin-vendored",
+ "siphasher 1.0.2",
+ "solana-pubkey 4.1.0",
+ "thiserror 2.0.18",
  "tonic",
  "tonic-prost",
  "tonic-prost-build",
@@ -9069,17 +8953,17 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "clap",
+ "crossbeam-channel",
  "futures-channel",
  "futures-util",
  "serde",
  "smallvec",
  "thiserror 1.0.69",
  "tokio",
- "topograph",
  "tracing",
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",
@@ -9088,7 +8972,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-block-coordinator"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "bs58",
@@ -9112,7 +8996,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-block-meta-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "prost",
  "prost-types",
@@ -9123,7 +9007,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-core"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "borsh 1.6.1",
  "bs58",
@@ -9138,7 +9022,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-kafka-sink"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "futures",
  "prost",
@@ -9156,7 +9040,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-mock"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "futures",
  "regex",
@@ -9172,7 +9056,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -9185,7 +9069,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-proc-macro"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -9201,7 +9085,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-proto"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "prost",
  "protobuf-src",
@@ -9210,7 +9094,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-spl-token-extensions-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "borsh 1.6.1",
  "bs58",
@@ -9234,7 +9118,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-spl-token-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bs58",
  "prost",
@@ -9251,7 +9135,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-stake-pool-parser"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "borsh 1.6.1",
  "bs58",
@@ -9267,7 +9151,7 @@ dependencies = [
 
 [[package]]
 name = "yellowstone-vixen-yellowstone-grpc-source"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "async-trait",
  "clap",


### PR DESCRIPTION
## Summary

Ensure Kafka account parsing only invokes the parser associated with the account owner.

## Problem

`KafkaSink::parse_account` iterated over every registered account parser and called `DynAccountParser::try_parse` directly.

The account subscription receives the combined set of owners for all registered parsers. Once an account reaches the Kafka sink, the sink must therefore dispatch it to the parser for its specific owner.

That per-parser owner check was missing. A parser could receive an account owned by another program and attempt to decode it. If the account data happened to resemble that parser’s layout, the parser could return a real decoding error instead of `ParseError::Filtered`. The Kafka sink would then emit a fallback record for the wrong parser and stop trying the remaining parsers.

For example, the SPL Token parser dispatches on known account data lengths. A 165-byte account owned by another program could therefore produce an incorrectly routed fallback record.

## Fix

- Compare each account parser’s program_id() with the account owner before invoking it.
- Unrelated parsers are skipped without recording a parse error or emitting a fallback record.
- Add a regression test verifying that an unrelated account does not invoke the parser and does not produce a fallback record.

## Impact

This prevents cross-program account decoding and incorrectly routed fallback records.